### PR TITLE
Add encrypted offline queue with observability tools

### DIFF
--- a/lib/services/offline_queue_encryption.dart
+++ b/lib/services/offline_queue_encryption.dart
@@ -1,0 +1,208 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Manages encryption of offline queue payloads using an AES-GCM keyring.
+///
+/// Keys are stored locally in [SharedPreferences] so that encrypted payloads can
+/// be decrypted across restarts. The manager keeps a rolling keyring and
+/// supports key rotation to limit exposure if a key is compromised.
+class OfflineQueueEncryption {
+  OfflineQueueEncryption({SharedPreferences? initialPrefs})
+      : _prefs = initialPrefs,
+        _cipher = AesGcm.with256bits(),
+        _random = Random.secure();
+
+  static const _keyringPref = 'sync_queue_keyring_v1';
+  static const _activeKeyIdPref = 'sync_queue_active_key_id_v1';
+
+  final Cipher _cipher;
+  final Random _random;
+
+  SharedPreferences? _prefs;
+  List<_KeyEntry>? _keyring;
+  String? _activeKeyId;
+
+  Future<SharedPreferences> _getPrefs() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  /// Encrypts a JSON serialisable payload and returns a base64 encoded blob.
+  Future<String> encryptPayload(Map<String, dynamic> payload) async {
+    await _ensureKeyring();
+    final key = _activeKey;
+    final secretKey = SecretKey(base64Decode(key.value));
+    final nonce = _randomBytes(12);
+    final bytes = utf8.encode(jsonEncode(payload));
+    final box = await _cipher.encrypt(
+      bytes,
+      secretKey: secretKey,
+      nonce: nonce,
+    );
+    final encoded = <String, dynamic>{
+      'keyId': key.id,
+      'nonce': base64Encode(box.nonce),
+      'cipherText': base64Encode(box.cipherText),
+      'mac': base64Encode(box.mac.bytes),
+    };
+    return jsonEncode(encoded);
+  }
+
+  /// Decrypts a previously encrypted payload back into its JSON structure.
+  Future<Map<String, dynamic>> decryptPayload(String encrypted) async {
+    await _ensureKeyring();
+    final decoded = jsonDecode(encrypted);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected encrypted payload format');
+    }
+    final keyId = decoded['keyId'] as String?;
+    if (keyId == null) {
+      throw const FormatException('Encrypted payload missing keyId');
+    }
+    final key = _keyring!.firstWhere(
+      (entry) => entry.id == keyId,
+      orElse: () => throw StateError('Unknown keyId $keyId for queue payload'),
+    );
+    final secretKey = SecretKey(base64Decode(key.value));
+    final nonce = base64Decode(decoded['nonce'] as String);
+    final cipherText = base64Decode(decoded['cipherText'] as String);
+    final macBytes = base64Decode(decoded['mac'] as String);
+    final box = SecretBox(
+      cipherText,
+      nonce: nonce,
+      mac: Mac(macBytes),
+    );
+    final decrypted = await _cipher.decrypt(
+      box,
+      secretKey: secretKey,
+    );
+    final jsonMap = jsonDecode(utf8.decode(decrypted));
+    if (jsonMap is! Map<String, dynamic>) {
+      throw const FormatException('Decrypted payload is not a JSON object');
+    }
+    return jsonMap;
+  }
+
+  /// Rotates the encryption key and re-encrypts provided payloads.
+  ///
+  /// Returns the payloads encrypted with the freshly generated key.
+  Future<List<String>> rotateKeyAndReencrypt(List<String> encryptedPayloads) async {
+    await _ensureKeyring();
+    final newKey = _generateKey();
+    _keyring!.add(newKey);
+    _activeKeyId = newKey.id;
+    await _persistKeyring();
+
+    final reencrypted = <String>[];
+    for (final payload in encryptedPayloads) {
+      try {
+        final json = await decryptPayload(payload);
+        final encrypted = await encryptPayload(json);
+        reencrypted.add(encrypted);
+      } catch (error, stackTrace) {
+        debugPrint('Failed to re-encrypt queue payload: $error');
+        debugPrint(stackTrace.toString());
+        reencrypted.add(payload);
+      }
+    }
+
+    _pruneKeyring();
+    await _persistKeyring();
+    return reencrypted;
+  }
+
+  Future<void> _ensureKeyring() async {
+    if (_keyring != null && _activeKeyId != null) {
+      return;
+    }
+    final prefs = await _getPrefs();
+    final stored = prefs.getStringList(_keyringPref) ?? <String>[];
+    _keyring = stored
+        .map((raw) => _KeyEntry.fromJson(jsonDecode(raw) as Map<String, dynamic>))
+        .toList();
+    _activeKeyId = prefs.getString(_activeKeyIdPref);
+    if (_keyring!.isEmpty ||
+        _activeKeyId == null ||
+        !_keyring!.any((entry) => entry.id == _activeKeyId)) {
+      final key = _generateKey();
+      _keyring!
+        ..clear()
+        ..add(key);
+      _activeKeyId = key.id;
+      await _persistKeyring();
+    }
+  }
+
+  void _pruneKeyring({int keep = 3}) {
+    if (_keyring!.length <= keep) {
+      return;
+    }
+    _keyring!.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final retained = _keyring!.take(keep).toList(growable: false);
+    _keyring!
+      ..clear()
+      ..addAll(retained);
+    if (!_keyring!.any((entry) => entry.id == _activeKeyId)) {
+      _activeKeyId = _keyring!.first.id;
+    }
+  }
+
+  Future<void> _persistKeyring() async {
+    final prefs = await _getPrefs();
+    final encoded = _keyring!
+        .map((entry) => jsonEncode(entry.toJson()))
+        .toList(growable: false);
+    await prefs.setStringList(_keyringPref, encoded);
+    await prefs.setString(_activeKeyIdPref, _activeKeyId!);
+  }
+
+  List<int> _randomBytes(int length) {
+    return List<int>.generate(length, (_) => _random.nextInt(256));
+  }
+
+  _KeyEntry get _activeKey {
+    return _keyring!.firstWhere((entry) => entry.id == _activeKeyId);
+  }
+
+  _KeyEntry _generateKey() {
+    final id = DateTime.now().millisecondsSinceEpoch.toString();
+    final keyData = List<int>.generate(32, (_) => _random.nextInt(256));
+    return _KeyEntry(
+      id: id,
+      value: base64Encode(keyData),
+      createdAt: DateTime.now(),
+    );
+  }
+}
+
+class _KeyEntry {
+  _KeyEntry({
+    required this.id,
+    required this.value,
+    required this.createdAt,
+  });
+
+  factory _KeyEntry.fromJson(Map<String, dynamic> json) {
+    return _KeyEntry(
+      id: json['id'] as String,
+      value: json['value'] as String,
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  final String id;
+  final String value;
+  final DateTime createdAt;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'value': value,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/services/ops_observability_service.dart
+++ b/lib/services/ops_observability_service.dart
@@ -1,0 +1,118 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+enum OpsLogLevel { debug, info, warning, error }
+
+class OpsLogEntry {
+  OpsLogEntry({
+    required this.level,
+    required this.message,
+    required this.timestamp,
+    this.context,
+    this.error,
+    this.stackTrace,
+  });
+
+  final OpsLogLevel level;
+  final String message;
+  final DateTime timestamp;
+  final Map<String, dynamic>? context;
+  final String? error;
+  final String? stackTrace;
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'level': level.name,
+      'message': message,
+      'timestamp': Timestamp.fromDate(timestamp),
+      if (context != null) 'context': context,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
+    };
+  }
+}
+
+class OpsObservabilityService extends ChangeNotifier {
+  OpsObservabilityService(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  final List<OpsLogEntry> _entries = <OpsLogEntry>[];
+  bool _overlayVisible = false;
+  bool _remoteLoggingEnabled = true;
+
+  List<OpsLogEntry> get entries => List.unmodifiable(_entries);
+  bool get overlayVisible => _overlayVisible;
+  bool get remoteLoggingEnabled => _remoteLoggingEnabled;
+
+  set remoteLoggingEnabled(bool value) {
+    if (_remoteLoggingEnabled == value) {
+      return;
+    }
+    _remoteLoggingEnabled = value;
+    notifyListeners();
+  }
+
+  Future<void> log(
+    String message, {
+    OpsLogLevel level = OpsLogLevel.info,
+    Map<String, dynamic>? context,
+    Object? error,
+    StackTrace? stackTrace,
+    bool sendRemote = true,
+  }) async {
+    final entry = OpsLogEntry(
+      level: level,
+      message: message,
+      timestamp: DateTime.now(),
+      context: context,
+      error: error?.toString(),
+      stackTrace: stackTrace?.toString(),
+    );
+    _entries.insert(0, entry);
+    if (_entries.length > 200) {
+      _entries.removeLast();
+    }
+    notifyListeners();
+
+    if (_remoteLoggingEnabled && sendRemote) {
+      try {
+        await _firestore.collection('opsLogs').add(entry.toFirestore());
+      } catch (e, st) {
+        final fallback = OpsLogEntry(
+          level: OpsLogLevel.error,
+          message: 'Failed to send remote log: $e',
+          timestamp: DateTime.now(),
+          error: e.toString(),
+          stackTrace: st.toString(),
+        );
+        _entries.insert(0, fallback);
+        if (_entries.length > 200) {
+          _entries.removeLast();
+        }
+        notifyListeners();
+      }
+    }
+  }
+
+  void toggleOverlay() {
+    _overlayVisible = !_overlayVisible;
+    notifyListeners();
+  }
+
+  void hideOverlay() {
+    if (!_overlayVisible) {
+      return;
+    }
+    _overlayVisible = false;
+    notifyListeners();
+  }
+
+  void addLocalEntry(OpsLogEntry entry) {
+    _entries.insert(0, entry);
+    if (_entries.length > 200) {
+      _entries.removeLast();
+    }
+    notifyListeners();
+  }
+}

--- a/lib/widgets/ops_debug_overlay.dart
+++ b/lib/widgets/ops_debug_overlay.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/ops_observability_service.dart';
+import '../services/sync_queue_service.dart';
+
+class OpsDebugOverlayHost extends StatelessWidget {
+  const OpsDebugOverlayHost({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        const _OpsDebugOverlay(),
+      ],
+    );
+  }
+}
+
+class _OpsDebugOverlay extends StatelessWidget {
+  const _OpsDebugOverlay();
+
+  Color _levelColor(OpsLogLevel level, ThemeData theme) {
+    switch (level) {
+      case OpsLogLevel.debug:
+        return theme.colorScheme.secondary;
+      case OpsLogLevel.info:
+        return theme.colorScheme.primary;
+      case OpsLogLevel.warning:
+        return Colors.orange;
+      case OpsLogLevel.error:
+        return theme.colorScheme.error;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<OpsObservabilityService>(
+      builder: (context, ops, child) {
+        final theme = Theme.of(context);
+        final handle = Align(
+          alignment: Alignment.bottomRight,
+          child: SafeArea(
+            minimum: const EdgeInsets.all(12),
+            child: FloatingActionButton.small(
+              heroTag: '_ops_debug_toggle',
+              onPressed: ops.toggleOverlay,
+              child: Icon(
+                ops.overlayVisible ? Icons.bug_report : Icons.bug_report_outlined,
+              ),
+            ),
+          ),
+        );
+
+        if (!ops.overlayVisible) {
+          return IgnorePointer(ignoring: false, child: handle);
+        }
+
+        return Stack(
+          children: [
+            handle,
+            Align(
+              alignment: Alignment.bottomRight,
+              child: SafeArea(
+                minimum: const EdgeInsets.all(12),
+                child: SizedBox(
+                  width: 360,
+                  height: 320,
+                  child: Material(
+                    elevation: 12,
+                    borderRadius: BorderRadius.circular(12),
+                    clipBehavior: Clip.antiAlias,
+                    color: theme.colorScheme.surface,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Container(
+                          color: theme.colorScheme.primaryContainer,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 8,
+                          ),
+                          child: Row(
+                            children: [
+                              const Icon(Icons.monitor_heart),
+                              const SizedBox(width: 8),
+                              const Expanded(
+                                child: Text(
+                                  'Ops Debug Console',
+                                  style: TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                              ),
+                              Switch(
+                                value: ops.remoteLoggingEnabled,
+                                onChanged: (value) =>
+                                    ops.remoteLoggingEnabled = value,
+                              ),
+                              const SizedBox(width: 4),
+                              const Text('Remote'),
+                              IconButton(
+                                tooltip: 'Rotate queue key',
+                                icon: const Icon(Icons.vpn_key),
+                                onPressed: () async {
+                                  final queueService =
+                                      context.read<SyncQueueService>();
+                                  await queueService.rotateEncryptionKey();
+                                },
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.close),
+                                onPressed: ops.hideOverlay,
+                              ),
+                            ],
+                          ),
+                        ),
+                        Expanded(
+                          child: ListView.builder(
+                            itemCount: ops.entries.length,
+                            itemBuilder: (context, index) {
+                              final entry = ops.entries[index];
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 8,
+                                ),
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    border: Border(
+                                      left: BorderSide(
+                                        color: _levelColor(entry.level, theme),
+                                        width: 4,
+                                      ),
+                                    ),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(left: 12),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          '[${entry.level.name.toUpperCase()}] '
+                                          '${entry.timestamp.toIso8601String()}',
+                                          style: theme.textTheme.labelSmall,
+                                        ),
+                                        const SizedBox(height: 4),
+                                        Text(entry.message),
+                                        if (entry.error != null) ...[
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            entry.error!,
+                                            style: theme.textTheme.bodySmall
+                                                ?.copyWith(color: theme.colorScheme.error),
+                                          ),
+                                        ],
+                                        if (entry.context != null) ...[
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            entry.context!.toString(),
+                                            style: theme.textTheme.bodySmall,
+                                          ),
+                                        ],
+                                        if (entry.stackTrace != null) ...[
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            entry.stackTrace!,
+                                            style: theme.textTheme.bodySmall,
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   connectivity_plus: ^6.0.3
   google_fonts: ^5.0.0
   flutter_slidable: ^3.0.0
+  cryptography: ^2.7.0
 
   
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- encrypt persisted sync queue operations with AES-GCM and add rotation utilities with automatic migration support
- introduce an Ops observability service that streams logs to Firestore and exposes a debug overlay with controls like manual key rotation
- wire the overlay into the app shell and enable the queue to emit observability events

## Testing
- `flutter pub get` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d40b93b7208325a55b4290583018ea