### PR TITLE
Add multi-environment release channels and experiment service

### DIFF
--- a/lib/feature_flags/feature_flag_configuration.dart
+++ b/lib/feature_flags/feature_flag_configuration.dart
@@ -1,52 +1,256 @@
+import 'dart:convert';
+
+import 'release_environment.dart';
+
 class FeatureFlagConfiguration {
-  final Map<String, bool> tenantFlags;
-  final Map<String, Map<String, bool>> storeFlags;
-  final Map<String, Map<String, bool>> terminalFlags;
-
   const FeatureFlagConfiguration({
-    required this.tenantFlags,
-    required this.storeFlags,
-    required this.terminalFlags,
-  });
+    required EnvironmentConfiguration global,
+    required this.environments,
+    required this.releaseChannels,
+    required this.experiments,
+  }) : _global = global;
 
-  factory FeatureFlagConfiguration.empty() => const FeatureFlagConfiguration(
-    tenantFlags: {},
-    storeFlags: {},
-    terminalFlags: {},
-  );
+  final EnvironmentConfiguration _global;
+  final Map<ReleaseEnvironment, EnvironmentConfiguration> environments;
+  final Map<String, ReleaseChannelConfiguration> releaseChannels;
+  final Map<String, ExperimentDefinition> experiments;
+
+  static const String defaultReleaseChannel = kDefaultReleaseChannel;
+
+  Map<String, bool> get tenantFlags => _global.tenantFlags;
+  Map<String, Map<String, bool>> get storeFlags => _global.storeFlags;
+  Map<String, Map<String, bool>> get terminalFlags => _global.terminalFlags;
+
+  EnvironmentConfiguration get global => _global;
+
+  factory FeatureFlagConfiguration.empty() => FeatureFlagConfiguration(
+        global: EnvironmentConfiguration.empty(),
+        environments: const {},
+        releaseChannels: const {},
+        experiments: const {},
+      );
 
   factory FeatureFlagConfiguration.fromMap(Map<String, dynamic> data) {
-    Map<String, bool> _toBoolMap(dynamic value) {
+    EnvironmentConfiguration parseEnvironment(dynamic value) {
       if (value is Map<String, dynamic>) {
-        return value.map(
-          (key, dynamic flagValue) => MapEntry(key, flagValue == true),
-        );
+        return EnvironmentConfiguration.fromMap(value);
       }
-      return {};
+      return EnvironmentConfiguration.empty();
     }
 
-    Map<String, Map<String, bool>> _toNestedMap(dynamic value) {
-      if (value is Map<String, dynamic>) {
-        return value.map(
-          (key, dynamic nested) => MapEntry(key, _toBoolMap(nested)),
-        );
-      }
-      return {};
+    final global = EnvironmentConfiguration.fromFlatMap(data);
+
+    final envs = <ReleaseEnvironment, EnvironmentConfiguration>{};
+    final rawEnvironments = data['environments'] as Map<String, dynamic>?;
+    if (rawEnvironments != null) {
+      rawEnvironments.forEach((key, dynamic value) {
+        final environment = tryReleaseEnvironmentFromName(key);
+        if (environment != null) {
+          envs[environment] = parseEnvironment(value);
+        }
+      });
+    }
+
+    final channels = <String, ReleaseChannelConfiguration>{};
+    final rawChannels = data['releaseChannels'] as Map<String, dynamic>?;
+    if (rawChannels != null) {
+      rawChannels.forEach((key, dynamic value) {
+        if (value is Map<String, dynamic>) {
+          channels[key] = ReleaseChannelConfiguration.fromMap(value);
+        }
+      });
+    }
+
+    final experimentMap = <String, ExperimentDefinition>{};
+    final rawExperiments = data['experiments'] as Map<String, dynamic>?;
+    if (rawExperiments != null) {
+      rawExperiments.forEach((key, dynamic value) {
+        if (value is Map<String, dynamic>) {
+          experimentMap[key] = ExperimentDefinition.fromMap(key, value);
+        }
+      });
     }
 
     return FeatureFlagConfiguration(
-      tenantFlags: _toBoolMap(data['flags']),
-      storeFlags: _toNestedMap(data['stores']),
-      terminalFlags: _toNestedMap(data['terminals']),
+      global: global,
+      environments: envs,
+      releaseChannels: channels,
+      experiments: experimentMap,
     );
   }
 
-  bool isEnabled(String flag, {String? storeId, String? terminalId}) {
-    final effective = effectiveFlags(storeId: storeId, terminalId: terminalId);
+  Map<String, dynamic> toMap() {
+    return {
+      'flags': tenantFlags,
+      'stores': storeFlags,
+      'terminals': terminalFlags,
+      if (_global.rollouts.isNotEmpty)
+        'rollouts': _global.rollouts.map(
+          (key, value) => MapEntry(key, value.toMap()),
+        ),
+      if (environments.isNotEmpty)
+        'environments': environments.map(
+          (key, value) => MapEntry(key.wireName, value.toMap()),
+        ),
+      if (releaseChannels.isNotEmpty)
+        'releaseChannels': releaseChannels.map(
+          (key, value) => MapEntry(key, value.toMap()),
+        ),
+      if (experiments.isNotEmpty)
+        'experiments': experiments.map(
+          (key, value) => MapEntry(key, value.toMap()),
+        ),
+    };
+  }
+
+  ReleaseEnvironment resolveEnvironment(
+    ReleaseEnvironment requested,
+    String? releaseChannel,
+  ) {
+    if (releaseChannel != null && releaseChannels.containsKey(releaseChannel)) {
+      final channelConfig = releaseChannels[releaseChannel];
+      if (channelConfig?.environment != null) {
+        return channelConfig!.environment!;
+      }
+    }
+    return requested;
+  }
+
+  Map<String, bool> effectiveFlags({
+    String? storeId,
+    String? terminalId,
+    ReleaseEnvironment? environment,
+    String? releaseChannel,
+    String? rolloutUnitId,
+  }) {
+    final resolvedEnvironment = resolveEnvironment(
+      environment ?? ReleaseEnvironment.production,
+      releaseChannel,
+    );
+    final environmentConfig = environments[resolvedEnvironment];
+    final releaseConfig =
+        releaseChannel != null ? releaseChannels[releaseChannel] : null;
+
+    final merged = Map<String, bool>.from(
+      _global.collectFlags(storeId: storeId, terminalId: terminalId),
+    );
+    if (environmentConfig != null) {
+      merged.addAll(
+        environmentConfig.collectFlags(storeId: storeId, terminalId: terminalId),
+      );
+    }
+    if (releaseConfig != null && releaseConfig.flagOverrides.isNotEmpty) {
+      merged.addAll(releaseConfig.flagOverrides);
+    }
+
+    final unitId =
+        (rolloutUnitId ?? terminalId ?? storeId ?? '').trim();
+
+    final rolloutMap = <String, StagedRollout>{}
+      ..addAll(_global.rollouts)
+      ..addAll(environmentConfig?.rollouts ?? const {})
+      ..addAll(releaseConfig?.rollouts ?? const {});
+
+    if (rolloutMap.isNotEmpty) {
+      rolloutMap.forEach((flag, rollout) {
+        final baseValue = merged[flag] ?? false;
+        final resolved = rollout.apply(
+          unitId: unitId,
+          fallback: baseValue,
+          cohortKey: flag,
+        );
+        merged[flag] = resolved;
+      });
+    }
+
+    return merged;
+  }
+
+  bool isEnabled(
+    String flag, {
+    String? storeId,
+    String? terminalId,
+    ReleaseEnvironment? environment,
+    String? releaseChannel,
+    String? rolloutUnitId,
+  }) {
+    final effective = effectiveFlags(
+      storeId: storeId,
+      terminalId: terminalId,
+      environment: environment,
+      releaseChannel: releaseChannel,
+      rolloutUnitId: rolloutUnitId,
+    );
     return effective[flag] ?? false;
   }
 
-  Map<String, bool> effectiveFlags({String? storeId, String? terminalId}) {
+  ExperimentDefinition? resolveExperiment(
+    String experimentId, {
+    required ReleaseEnvironment environment,
+    String? releaseChannel,
+  }) {
+    final definition = experiments[experimentId];
+    if (definition == null) {
+      return null;
+    }
+    final resolvedEnvironment = resolveEnvironment(environment, releaseChannel);
+    if (!definition.isEligible(resolvedEnvironment, releaseChannel)) {
+      return null;
+    }
+    return definition;
+  }
+
+  Iterable<ExperimentDefinition> eligibleExperiments({
+    required ReleaseEnvironment environment,
+    String? releaseChannel,
+  }) {
+    return experiments.values.where(
+      (experiment) =>
+          experiment.isEligible(resolveEnvironment(environment, releaseChannel),
+              releaseChannel),
+    );
+  }
+}
+
+class EnvironmentConfiguration {
+  const EnvironmentConfiguration({
+    required this.tenantFlags,
+    required this.storeFlags,
+    required this.terminalFlags,
+    required this.rollouts,
+  });
+
+  final Map<String, bool> tenantFlags;
+  final Map<String, Map<String, bool>> storeFlags;
+  final Map<String, Map<String, bool>> terminalFlags;
+  final Map<String, StagedRollout> rollouts;
+
+  factory EnvironmentConfiguration.empty() => const EnvironmentConfiguration(
+        tenantFlags: {},
+        storeFlags: {},
+        terminalFlags: {},
+        rollouts: {},
+      );
+
+  factory EnvironmentConfiguration.fromFlatMap(Map<String, dynamic> data) {
+    return EnvironmentConfiguration(
+      tenantFlags: _toBoolMap(data['flags']),
+      storeFlags: _toNestedMap(data['stores']),
+      terminalFlags: _toNestedMap(data['terminals']),
+      rollouts: _toRolloutMap(data['rollouts']),
+    );
+  }
+
+  factory EnvironmentConfiguration.fromMap(Map<String, dynamic> data) {
+    return EnvironmentConfiguration(
+      tenantFlags: _toBoolMap(data['flags']),
+      storeFlags: _toNestedMap(data['stores']),
+      terminalFlags: _toNestedMap(data['terminals']),
+      rollouts: _toRolloutMap(data['rollouts']),
+    );
+  }
+
+  Map<String, bool> collectFlags({String? storeId, String? terminalId}) {
     final merged = Map<String, bool>.from(tenantFlags);
     if (storeId != null && storeFlags.containsKey(storeId)) {
       merged.addAll(storeFlags[storeId]!);
@@ -62,6 +266,341 @@ class FeatureFlagConfiguration {
       'flags': tenantFlags,
       'stores': storeFlags,
       'terminals': terminalFlags,
+      if (rollouts.isNotEmpty)
+        'rollouts': rollouts.map(
+          (key, value) => MapEntry(key, value.toMap()),
+        ),
     };
   }
+}
+
+class ReleaseChannelConfiguration {
+  const ReleaseChannelConfiguration({
+    this.environment,
+    this.flagOverrides = const {},
+    this.rollouts = const {},
+  });
+
+  final ReleaseEnvironment? environment;
+  final Map<String, bool> flagOverrides;
+  final Map<String, StagedRollout> rollouts;
+
+  factory ReleaseChannelConfiguration.fromMap(Map<String, dynamic> data) {
+    final environmentName = data['environment'] as String?;
+    return ReleaseChannelConfiguration(
+      environment: tryReleaseEnvironmentFromName(environmentName),
+      flagOverrides: _toBoolMap(data['flags']),
+      rollouts: _toRolloutMap(data['rollouts']),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      if (environment != null) 'environment': environment!.wireName,
+      if (flagOverrides.isNotEmpty) 'flags': flagOverrides,
+      if (rollouts.isNotEmpty)
+        'rollouts': rollouts.map(
+          (key, value) => MapEntry(key, value.toMap()),
+        ),
+    };
+  }
+}
+
+class StagedRollout {
+  const StagedRollout({
+    required this.percentage,
+    this.value = true,
+    this.seed,
+    this.rolloutId,
+  });
+
+  final double percentage;
+  final bool value;
+  final String? seed;
+  final String? rolloutId;
+
+  factory StagedRollout.fromMap(Map<String, dynamic> data) {
+    final rawPercentage = data['percentage'] ?? data['percent'];
+    double percentage;
+    if (rawPercentage is int) {
+      percentage = rawPercentage.toDouble();
+    } else if (rawPercentage is double) {
+      percentage = rawPercentage;
+    } else if (rawPercentage is String) {
+      percentage = double.tryParse(rawPercentage) ?? 0;
+    } else {
+      percentage = 0;
+    }
+    if (percentage > 1) {
+      percentage = percentage / 100.0;
+    }
+    percentage = percentage.clamp(0.0, 1.0);
+    final value = data['value'] == null ? true : data['value'] == true;
+    final seed = data['seed'] as String?;
+    final rolloutId = data['id'] as String?;
+    return StagedRollout(
+      percentage: percentage,
+      value: value,
+      seed: seed,
+      rolloutId: rolloutId,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    final map = {
+      'percentage': percentage,
+      'value': value,
+    };
+    if (seed != null) {
+      map['seed'] = seed;
+    }
+    if (rolloutId != null) {
+      map['id'] = rolloutId;
+    }
+    return map;
+  }
+
+  bool includes(String unitId, {String? cohortKey}) {
+    if (percentage <= 0) {
+      return false;
+    }
+    if (percentage >= 1) {
+      return true;
+    }
+    final trimmed = unitId.trim();
+    if (trimmed.isEmpty) {
+      return false;
+    }
+    final resolvedSeed = _composeSeed(cohortKey);
+    final hash = _stableHashDouble('$resolvedSeed::$trimmed');
+    return hash < percentage;
+  }
+
+  bool apply({
+    required String unitId,
+    required bool fallback,
+    String? cohortKey,
+  }) {
+    if (!includes(unitId, cohortKey: cohortKey)) {
+      return fallback;
+    }
+    return value;
+  }
+
+  String _composeSeed(String? cohortKey) {
+    final buffer = StringBuffer('rollout');
+    if (seed != null && seed!.isNotEmpty) {
+      buffer.write('::$seed');
+    }
+    if (rolloutId != null && rolloutId!.isNotEmpty) {
+      buffer.write('::$rolloutId');
+    }
+    if (cohortKey != null && cohortKey.isNotEmpty) {
+      buffer.write('::$cohortKey');
+    }
+    return buffer.toString();
+  }
+}
+
+class ExperimentDefinition {
+  ExperimentDefinition({
+    required this.id,
+    required Map<String, double> variants,
+    this.seed,
+    Set<ReleaseEnvironment>? environments,
+    Set<String>? channels,
+    this.rollout,
+    this.metadata = const {},
+    String? defaultVariant,
+  })  : variants = _normalizeVariants(variants),
+        environments = environments ?? ReleaseEnvironment.values.toSet(),
+        channels = channels ?? const {},
+        defaultVariant = defaultVariant ??
+            (variants.isNotEmpty ? variants.keys.first : 'control');
+
+  final String id;
+  final Map<String, double> variants;
+  final String? seed;
+  final Set<ReleaseEnvironment> environments;
+  final Set<String> channels;
+  final StagedRollout? rollout;
+  final Map<String, dynamic> metadata;
+  final String defaultVariant;
+
+  factory ExperimentDefinition.fromMap(
+    String id,
+    Map<String, dynamic> data,
+  ) {
+    final rawVariants = data['variants'];
+    Map<String, double> variants;
+    if (rawVariants is Map<String, dynamic>) {
+      variants = rawVariants.map((key, dynamic value) {
+        if (value is num) {
+          return MapEntry(key, value.toDouble());
+        }
+        if (value is String) {
+          return MapEntry(key, double.tryParse(value) ?? 0.0);
+        }
+        return MapEntry(key, 0.0);
+      });
+    } else {
+      variants = const {'control': 1.0};
+    }
+
+    final envList = (data['environments'] as List<dynamic>?)
+        ?.map((dynamic value) => tryReleaseEnvironmentFromName('$value'))
+        .whereType<ReleaseEnvironment>()
+        .toSet();
+    final singleEnvironment = data['environment'] is String
+        ? tryReleaseEnvironmentFromName(data['environment'] as String?)
+        : null;
+    final normalizedEnvironments = envList ??
+        (singleEnvironment != null ? {singleEnvironment} : null);
+
+    final channelSet = (data['channels'] as List<dynamic>?)
+            ?.map((dynamic value) => '$value')
+            .where((value) => value.isNotEmpty)
+            .toSet() ??
+        <String>{};
+
+    final rolloutData = data['rollout'];
+    final rollout = rolloutData is Map<String, dynamic>
+        ? StagedRollout.fromMap(rolloutData)
+        : null;
+
+    return ExperimentDefinition(
+      id: id,
+      variants: variants,
+      seed: data['seed'] as String?,
+      environments: normalizedEnvironments,
+      channels: channelSet.isEmpty ? null : channelSet,
+      rollout: rollout,
+      metadata: (data['metadata'] as Map<String, dynamic>?) ?? const {},
+      defaultVariant: data['defaultVariant'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'variants': variants,
+      if (seed != null) 'seed': seed,
+      if (environments.length != ReleaseEnvironment.values.length)
+        'environments': environments.map((env) => env.wireName).toList(),
+      if (channels.isNotEmpty) 'channels': channels.toList(),
+      if (rollout != null) 'rollout': rollout!.toMap(),
+      if (metadata.isNotEmpty) 'metadata': metadata,
+      if (defaultVariant.isNotEmpty) 'defaultVariant': defaultVariant,
+    };
+  }
+
+  bool isEligible(ReleaseEnvironment environment, String? releaseChannel) {
+    if (!environments.contains(environment)) {
+      return false;
+    }
+    if (channels.isEmpty) {
+      return true;
+    }
+    if (releaseChannel == null) {
+      return false;
+    }
+    return channels.contains(releaseChannel);
+  }
+
+  String assignVariant(String subjectKey) {
+    if (variants.isEmpty) {
+      return defaultVariant;
+    }
+
+    final resolvedSeed = _composeSeed();
+    final hash = _stableHashDouble('$resolvedSeed::$subjectKey');
+
+    double cumulative = 0;
+    String? selected;
+    variants.forEach((variant, weight) {
+      if (selected != null) {
+        return;
+      }
+      cumulative += weight;
+      if (hash <= cumulative) {
+        selected = variant;
+      }
+    });
+    return selected ?? variants.keys.last;
+  }
+
+  bool isSubjectEligible(String subjectKey) {
+    if (rollout == null) {
+      return true;
+    }
+    return rollout!.includes(subjectKey, cohortKey: id);
+  }
+
+  String _composeSeed() {
+    final buffer = StringBuffer('experiment::$id');
+    if (seed != null && seed!.isNotEmpty) {
+      buffer.write('::$seed');
+    }
+    return buffer.toString();
+  }
+}
+
+Map<String, bool> _toBoolMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value.map(
+      (key, dynamic flagValue) => MapEntry(key, flagValue == true),
+    );
+  }
+  return const {};
+}
+
+Map<String, Map<String, bool>> _toNestedMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value.map(
+      (key, dynamic nested) => MapEntry(key, _toBoolMap(nested)),
+    );
+  }
+  return const {};
+}
+
+Map<String, StagedRollout> _toRolloutMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value.map((key, dynamic rolloutData) {
+      if (rolloutData is Map<String, dynamic>) {
+        return MapEntry(key, StagedRollout.fromMap(rolloutData));
+      }
+      return MapEntry(key, const StagedRollout(percentage: 0));
+    });
+  }
+  return const {};
+}
+
+Map<String, double> _normalizeVariants(Map<String, double> variants) {
+  if (variants.isEmpty) {
+    return const {'control': 1.0};
+  }
+  double total = variants.values.fold(0.0, (sum, weight) => sum + weight);
+  if (total <= 0) {
+    total = variants.length.toDouble();
+    return variants.map((key, value) => MapEntry(key, 1 / total));
+  }
+  return variants.map(
+    (key, value) => MapEntry(key, value <= 0 ? 0 : value / total),
+  );
+}
+
+int _stableHash(String input) {
+  const int fnvPrime = 16777619;
+  const int fnvOffset = 2166136261;
+  int hash = fnvOffset;
+  for (final codeUnit in utf8.encode(input)) {
+    hash ^= codeUnit;
+    hash = (hash * fnvPrime) & 0xFFFFFFFF;
+  }
+  return hash;
+}
+
+double _stableHashDouble(String input) {
+  const double twoTo32 = 4294967296.0;
+  final hash = _stableHash(input);
+  return (hash & 0xFFFFFFFF) / twoTo32;
 }

--- a/lib/feature_flags/feature_flag_provider.dart
+++ b/lib/feature_flags/feature_flag_provider.dart
@@ -7,6 +7,7 @@ import '../services/client_cache_service.dart';
 import 'feature_flag_configuration.dart';
 import 'feature_flag_scope.dart';
 import 'feature_flag_service.dart';
+import 'release_environment.dart';
 
 class FeatureFlagProvider with ChangeNotifier {
   FeatureFlagProvider(this._featureFlagService, this._cacheService);
@@ -20,19 +21,35 @@ class FeatureFlagProvider with ChangeNotifier {
   String? _tenantId;
   String? _storeId;
   String? _terminalId;
+  ReleaseEnvironment _baseEnvironment = ReleaseEnvironment.production;
+  ReleaseEnvironment _environment = ReleaseEnvironment.production;
+  String _releaseChannel = FeatureFlagConfiguration.defaultReleaseChannel;
 
   FeatureFlagConfiguration get configuration => _configuration;
+  ReleaseEnvironment get environment => _environment;
+  String get releaseChannel => _releaseChannel;
 
-  Map<String, bool> get activeFlags =>
-      _configuration.effectiveFlags(storeId: _storeId, terminalId: _terminalId);
+  Map<String, bool> get activeFlags => _configuration.effectiveFlags(
+        storeId: _storeId,
+        terminalId: _terminalId,
+        environment: _environment,
+        releaseChannel: _releaseChannel,
+        rolloutUnitId: _rolloutUnitId,
+      );
 
   bool isEnabled(String flag) {
     return _configuration.isEnabled(
       flag,
       storeId: _storeId,
       terminalId: _terminalId,
+      environment: _environment,
+      releaseChannel: _releaseChannel,
+      rolloutUnitId: _rolloutUnitId,
     );
   }
+
+  String get _rolloutUnitId =>
+      _terminalId ?? _storeId ?? _tenantId ?? 'global';
 
   void updateContext({required Store? store, required String? terminalId}) {
     final tenantId = store?.tenantId;
@@ -41,6 +58,14 @@ class FeatureFlagProvider with ChangeNotifier {
     final tenantChanged = _tenantId != tenantId;
     final storeChanged = _storeId != storeId;
     final terminalChanged = _terminalId != terminalId;
+
+    final newReleaseChannel = store?.releaseChannel ??
+        FeatureFlagConfiguration.defaultReleaseChannel;
+    final newBaseEnvironment = store?.releaseEnvironment ??
+        ReleaseEnvironment.production;
+
+    final channelChanged = _releaseChannel != newReleaseChannel;
+    final environmentChanged = _baseEnvironment != newBaseEnvironment;
 
     if (tenantChanged) {
       _tenantId = tenantId;
@@ -52,6 +77,7 @@ class FeatureFlagProvider with ChangeNotifier {
           configuration,
         ) {
           _configuration = configuration;
+          _recomputeEnvironment();
           unawaited(
             _cacheService.cacheFeatureFlags(
               tenantId: tenantId,
@@ -71,15 +97,39 @@ class FeatureFlagProvider with ChangeNotifier {
       _terminalId = terminalId;
     }
 
-    if (tenantChanged || storeChanged || terminalChanged) {
+    if (channelChanged) {
+      _releaseChannel = newReleaseChannel;
+    }
+
+    if (environmentChanged) {
+      _baseEnvironment = newBaseEnvironment;
+    }
+
+    final envDidChange = _recomputeEnvironment();
+
+    if (tenantChanged || storeChanged || terminalChanged || channelChanged ||
+        environmentChanged || envDidChange) {
       notifyListeners();
     }
+  }
+
+  bool _recomputeEnvironment() {
+    final resolved = _configuration.resolveEnvironment(
+      _baseEnvironment,
+      _releaseChannel,
+    );
+    if (_environment != resolved) {
+      _environment = resolved;
+      return true;
+    }
+    return false;
   }
 
   Future<void> _loadCachedConfiguration(String tenantId) async {
     final cached = await _cacheService.readFeatureFlags(tenantId: tenantId);
     if (cached != null && _tenantId == tenantId) {
       _configuration = cached;
+      _recomputeEnvironment();
       notifyListeners();
     }
   }
@@ -90,6 +140,8 @@ class FeatureFlagProvider with ChangeNotifier {
     required bool isEnabled,
     String? storeId,
     String? terminalId,
+    ReleaseEnvironment? environment,
+    String? releaseChannel,
   }) async {
     final tenantId = _tenantId;
     if (tenantId == null) {
@@ -108,6 +160,8 @@ class FeatureFlagProvider with ChangeNotifier {
       isEnabled: isEnabled,
       storeId: resolvedStoreId,
       terminalId: resolvedTerminalId,
+      environment: environment,
+      releaseChannel: releaseChannel,
     );
   }
 

--- a/lib/feature_flags/feature_flag_service.dart
+++ b/lib/feature_flags/feature_flag_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'feature_flag_configuration.dart';
 import 'feature_flag_scope.dart';
+import 'release_environment.dart';
 
 class FeatureFlagService {
   FeatureFlagService(this._firestore);
@@ -26,30 +27,50 @@ class FeatureFlagService {
     required bool isEnabled,
     String? storeId,
     String? terminalId,
+    ReleaseEnvironment? environment,
+    String? releaseChannel,
   }) async {
     final docRef = _firestore.collection('featureFlags').doc(tenantId);
     final updates = <String, dynamic>{};
-    switch (scope) {
-      case FeatureFlagScope.tenant:
-        updates['flags.$flag'] = isEnabled;
-        break;
-      case FeatureFlagScope.store:
-        if (storeId == null || storeId.isEmpty) {
-          throw ArgumentError(
-            'storeId is required for store-scoped feature flags.',
-          );
-        }
-        updates['stores.$storeId.$flag'] = isEnabled;
-        break;
-      case FeatureFlagScope.terminal:
-        if (terminalId == null || terminalId.isEmpty) {
-          throw ArgumentError(
-            'terminalId is required for terminal-scoped feature flags.',
-          );
-        }
-        updates['terminals.$terminalId.$flag'] = isEnabled;
-        break;
+
+    String scopedPath(String base) {
+      switch (scope) {
+        case FeatureFlagScope.tenant:
+          return '$base.flags.$flag';
+        case FeatureFlagScope.store:
+          if (storeId == null || storeId.isEmpty) {
+            throw ArgumentError(
+              'storeId is required for store-scoped feature flags.',
+            );
+          }
+          return '$base.stores.$storeId.$flag';
+        case FeatureFlagScope.terminal:
+          if (terminalId == null || terminalId.isEmpty) {
+            throw ArgumentError(
+              'terminalId is required for terminal-scoped feature flags.',
+            );
+          }
+          return '$base.terminals.$terminalId.$flag';
+      }
     }
+
+    if (releaseChannel != null && releaseChannel.isNotEmpty) {
+      if (scope != FeatureFlagScope.tenant) {
+        throw ArgumentError(
+          'Release channel overrides currently support tenant scope only.',
+        );
+      }
+      final path = scopedPath('releaseChannels.$releaseChannel');
+      updates[path] = isEnabled;
+    } else if (environment != null) {
+      final envKey = environment.wireName;
+      final path = scopedPath('environments.$envKey');
+      updates[path] = isEnabled;
+    } else {
+      final path = scopedPath('');
+      updates[path] = isEnabled;
+    }
+
     await docRef.set(updates, SetOptions(merge: true));
   }
 }

--- a/lib/feature_flags/release_environment.dart
+++ b/lib/feature_flags/release_environment.dart
@@ -1,0 +1,46 @@
+enum ReleaseEnvironment { development, staging, production }
+
+extension ReleaseEnvironmentName on ReleaseEnvironment {
+  String get wireName {
+    switch (this) {
+      case ReleaseEnvironment.development:
+        return 'dev';
+      case ReleaseEnvironment.staging:
+        return 'stg';
+      case ReleaseEnvironment.production:
+        return 'prod';
+    }
+  }
+}
+
+ReleaseEnvironment releaseEnvironmentFromName(
+  String? value, {
+  ReleaseEnvironment fallback = ReleaseEnvironment.production,
+}) {
+  return tryReleaseEnvironmentFromName(value) ?? fallback;
+}
+
+ReleaseEnvironment? tryReleaseEnvironmentFromName(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  final normalized = value.trim().toLowerCase();
+  for (final environment in ReleaseEnvironment.values) {
+    if (environment.name.toLowerCase() == normalized ||
+        environment.wireName == normalized) {
+      return environment;
+    }
+  }
+  if (normalized == 'stage' || normalized == 'staging') {
+    return ReleaseEnvironment.staging;
+  }
+  if (normalized == 'prod' || normalized == 'production') {
+    return ReleaseEnvironment.production;
+  }
+  if (normalized == 'dev' || normalized == 'development') {
+    return ReleaseEnvironment.development;
+  }
+  return null;
+}
+
+const String kDefaultReleaseChannel = 'prod';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,6 +67,7 @@ import 'services/menu_cache_provider.dart';
 import 'services/printer_drawer_service.dart';
 import 'services/schema_migration_runner.dart';
 import 'services/ops_observability_service.dart';
+import 'services/experiment_service.dart';
 import 'feature_flags/feature_flag_provider.dart';
 import 'feature_flags/feature_flag_service.dart';
 import 'feature_flags/terminal_provider.dart';
@@ -442,6 +443,35 @@ class MyApp extends StatelessWidget {
               terminalId: terminalProvider.terminalId,
             );
             return provider;
+          },
+        ),
+        ChangeNotifierProxyProvider3<
+          FeatureFlagProvider,
+          StoreProvider,
+          TerminalProvider,
+          ExperimentService
+        >(
+          create: (ctx) => ExperimentService(FirebaseFirestore.instance),
+          update: (
+            ctx,
+            featureFlags,
+            storeProvider,
+            terminalProvider,
+            experimentService,
+          ) {
+            final service = experimentService ??
+                ExperimentService(FirebaseFirestore.instance);
+            service.updateConfiguration(featureFlags.configuration);
+            service.updateEnvironment(
+              featureFlags.environment,
+              featureFlags.releaseChannel,
+            );
+            service.updateContext(
+              tenantId: storeProvider.activeStore?.tenantId,
+              storeId: storeProvider.activeStore?.id,
+              terminalId: terminalProvider.terminalId,
+            );
+            return service;
           },
         ),
         ChangeNotifierProvider(

--- a/lib/services/experiment_service.dart
+++ b/lib/services/experiment_service.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import '../feature_flags/feature_flag_configuration.dart';
+import '../feature_flags/release_environment.dart';
+
+class ExperimentService extends ChangeNotifier {
+  ExperimentService(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  FeatureFlagConfiguration _configuration = FeatureFlagConfiguration.empty();
+  ReleaseEnvironment _environment = ReleaseEnvironment.production;
+  String _releaseChannel = FeatureFlagConfiguration.defaultReleaseChannel;
+  String? _tenantId;
+  String? _storeId;
+  String? _terminalId;
+
+  final Map<String, String> _assignments = {};
+  final Map<String, bool> _exposureLogged = {};
+
+  FeatureFlagConfiguration get configuration => _configuration;
+  ReleaseEnvironment get environment => _environment;
+  String get releaseChannel => _releaseChannel;
+  String? get tenantId => _tenantId;
+  String? get storeId => _storeId;
+  String? get terminalId => _terminalId;
+
+  Iterable<ExperimentDefinition> get activeExperiments =>
+      _configuration.eligibleExperiments(
+        environment: _environment,
+        releaseChannel: _releaseChannel,
+      );
+
+  void updateConfiguration(FeatureFlagConfiguration configuration) {
+    _configuration = configuration;
+    _pruneAssignments();
+    notifyListeners();
+  }
+
+  void updateEnvironment(
+    ReleaseEnvironment environment,
+    String releaseChannel,
+  ) {
+    if (_environment == environment && _releaseChannel == releaseChannel) {
+      return;
+    }
+    _environment = environment;
+    _releaseChannel = releaseChannel;
+    _pruneAssignments();
+    notifyListeners();
+  }
+
+  void updateContext({
+    String? tenantId,
+    String? storeId,
+    String? terminalId,
+  }) {
+    final previousSubject = _subjectKey;
+    bool changed = false;
+    if (_tenantId != tenantId) {
+      _tenantId = tenantId;
+      changed = true;
+    }
+    if (_storeId != storeId) {
+      _storeId = storeId;
+      changed = true;
+    }
+    if (_terminalId != terminalId) {
+      _terminalId = terminalId;
+      changed = true;
+    }
+    if (changed && previousSubject != _subjectKey) {
+      _assignments.clear();
+      _exposureLogged.clear();
+    }
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  String? getVariant(
+    String experimentId, {
+    String? subjectId,
+    bool logExposure = true,
+  }) {
+    final experiment = _configuration.resolveExperiment(
+      experimentId,
+      environment: _environment,
+      releaseChannel: _releaseChannel,
+    );
+    if (experiment == null) {
+      _assignments.remove(experimentId);
+      _exposureLogged.remove(experimentId);
+      return null;
+    }
+
+    final subjectKey = subjectId ?? _subjectKey;
+    if (subjectKey.isEmpty) {
+      return null;
+    }
+
+    if (!experiment.isSubjectEligible(subjectKey)) {
+      _assignments[experimentId] = experiment.defaultVariant;
+      return experiment.defaultVariant;
+    }
+
+    final variant = experiment.assignVariant(subjectKey);
+    _assignments[experimentId] = variant;
+
+    if (logExposure && !(_exposureLogged[experimentId] ?? false)) {
+      _exposureLogged[experimentId] = true;
+      unawaited(
+        logExposureEvent(
+          experimentId,
+          variant: variant,
+          subjectKey: subjectKey,
+        ),
+      );
+    }
+
+    return variant;
+  }
+
+  String? getAssignedVariant(String experimentId) =>
+      _assignments[experimentId];
+
+  Future<void> logExposureEvent(
+    String experimentId, {
+    String? variant,
+    String? subjectKey,
+    Map<String, dynamic>? metadata,
+  }) async {
+    final resolvedVariant = variant ?? _assignments[experimentId];
+    if (resolvedVariant == null) {
+      return;
+    }
+    final payload = _buildEventPayload(
+      experimentId,
+      resolvedVariant,
+      'exposure',
+      subjectKey: subjectKey,
+      metadata: metadata,
+    );
+    await _firestore.collection('experimentEvents').add(payload);
+  }
+
+  Future<void> logConversion(
+    String experimentId, {
+    String? variant,
+    String? subjectKey,
+    String conversion = 'conversion',
+    Map<String, dynamic>? metadata,
+  }) async {
+    final resolvedVariant = variant ?? _assignments[experimentId];
+    if (resolvedVariant == null) {
+      return;
+    }
+    final payload = _buildEventPayload(
+      experimentId,
+      resolvedVariant,
+      conversion,
+      subjectKey: subjectKey,
+      metadata: metadata,
+    );
+    await _firestore.collection('experimentEvents').add(payload);
+  }
+
+  Map<String, dynamic> _buildEventPayload(
+    String experimentId,
+    String variant,
+    String eventType, {
+    String? subjectKey,
+    Map<String, dynamic>? metadata,
+  }) {
+    return {
+      'experimentId': experimentId,
+      'variant': variant,
+      'event': eventType,
+      'timestamp': Timestamp.now(),
+      'environment': _environment.wireName,
+      'releaseChannel': _releaseChannel,
+      if (_tenantId != null) 'tenantId': _tenantId,
+      if (_storeId != null) 'storeId': _storeId,
+      if (_terminalId != null) 'terminalId': _terminalId,
+      if (subjectKey != null) 'subject': subjectKey,
+      if (metadata != null && metadata.isNotEmpty) 'metadata': metadata,
+    };
+  }
+
+  void _pruneAssignments() {
+    final activeIds = activeExperiments.map((e) => e.id).toSet();
+    _assignments.removeWhere((key, value) => !activeIds.contains(key));
+    _exposureLogged.removeWhere((key, value) => !activeIds.contains(key));
+  }
+
+  String get _subjectKey =>
+      _terminalId ?? _storeId ?? _tenantId ?? '';
+}


### PR DESCRIPTION
## Summary
- extend feature flag configuration to support environment overrides, release channel staged rollouts, and experiment definitions
- persist store release metadata and expose environment-aware flag evaluation through the provider/service stack
- introduce an ExperimentService with exposure/conversion logging and register it in the app container

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d49b11c3c48325bde4b967d5fe53c9