### PR TITLE
Fix dynamic form switch exhaustiveness and update frame timing test

### DIFF
--- a/lib/widgets/dynamic_forms/dynamic_form.dart
+++ b/lib/widgets/dynamic_forms/dynamic_form.dart
@@ -188,6 +188,9 @@ class _DynamicFormState extends State<DynamicForm>
       case DateFieldSchema dateField:
         return _buildDateField(dateField);
     }
+    throw UnsupportedError(
+      'Unsupported dynamic form field type: ${field.runtimeType}',
+    );
   }
 
   Widget _buildTextField(TextFieldSchema field) {

--- a/test/frame_jank_metrics_test.dart
+++ b/test/frame_jank_metrics_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -40,11 +42,11 @@ void main() {
     expect(timings, isNotEmpty, reason: 'No frame timings were collected');
 
     final summary = FrameTimingSummarizer(timings);
-    expect(summary.buildFrameRate, greaterThanOrEqualTo(55));
-    expect(summary.rasterizerFrameRate, greaterThanOrEqualTo(55));
-    expect(summary.averageBuildTimeMillis, lessThan(8),
+    expect(summary.frameBuildRate, greaterThanOrEqualTo(55));
+    expect(summary.frameRasterizerRate, greaterThanOrEqualTo(55));
+    expect(summary.averageFrameBuildTimeMillis, lessThan(8),
         reason: 'Build time should stay well below a frame budget');
-    expect(summary.averageRasterizerTimeMillis, lessThan(8),
+    expect(summary.averageFrameRasterizerTimeMillis, lessThan(8),
         reason: 'Rasterizer time should stay well below a frame budget');
   });
 }


### PR DESCRIPTION
## Summary
- add an explicit UnsupportedError for unhandled dynamic form field types
- update the frame jank metrics test to import FrameTiming and use current FrameTimingSummarizer API names

## Testing
- flutter test test/frame_jank_metrics_test.dart *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d55a310870832582a05a0ee21d7d09