### PR TITLE
Add localization infrastructure with currency and unit formatting

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations
+use-deferred-loading: false

--- a/lib/ingredient_management_page.dart
+++ b/lib/ingredient_management_page.dart
@@ -2,9 +2,14 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:restaurant_models/restaurant_models.dart';
 
 import 'add_purchase_order_page.dart'; // <-- 1. Add this import
+import 'currency_provider.dart';
+import 'locale_provider.dart';
+import 'localization/localization_extensions.dart';
 class IngredientManagementPage extends StatefulWidget {
   const IngredientManagementPage({super.key});
 
@@ -30,6 +35,7 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
 
   void _showIngredientDialog({Ingredient? ingredient}) {
     final isNew = ingredient == null;
+    final l10n = AppLocalizations.of(context)!;
     final nameController = TextEditingController(text: ingredient?.name);
     final unitController = TextEditingController(text: ingredient?.unit);
     final stockController = TextEditingController(
@@ -47,7 +53,11 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'เพิ่มวัตถุดิบใหม่' : 'แก้ไขวัตถุดิบ'),
+          title: Text(
+            isNew
+                ? l10n.ingredientDialogCreateTitle
+                : l10n.ingredientDialogEditTitle,
+          ),
           content: Form(
             key: formKey,
             child: SingleChildScrollView(
@@ -56,52 +66,60 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
                 children: [
                   TextFormField(
                     controller: nameController,
-                    decoration: const InputDecoration(
-                      labelText: 'ชื่อวัตถุดิบ',
+                    decoration: InputDecoration(
+                      labelText: l10n.ingredientFieldNameLabel,
                     ),
                     validator: (value) =>
-                        (value?.isEmpty ?? true) ? 'กรุณากรอกชื่อ' : null,
+                        (value?.isEmpty ?? true)
+                            ? l10n.ingredientFieldNameValidation
+                            : null,
                   ),
                   TextFormField(
                     controller: unitController,
-                    decoration: const InputDecoration(
-                      labelText: 'หน่วยนับ (เช่น kg, g, ชิ้น)',
+                    decoration: InputDecoration(
+                      labelText: l10n.ingredientFieldUnitLabel,
                     ),
                     validator: (value) =>
-                        (value?.isEmpty ?? true) ? 'กรุณากรอกหน่วยนับ' : null,
+                        (value?.isEmpty ?? true)
+                            ? l10n.ingredientFieldUnitValidation
+                            : null,
                   ),
                   TextFormField(
                     controller: stockController,
-                    decoration: const InputDecoration(
-                      labelText: 'จำนวนในสต็อก',
+                    decoration: InputDecoration(
+                      labelText: l10n.ingredientFieldStockLabel,
                     ),
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                     ),
                     validator: (value) =>
-                        (value?.isEmpty ?? true) ? 'กรุณากรอกจำนวน' : null,
+                        (value?.isEmpty ?? true)
+                            ? l10n.ingredientFieldStockValidation
+                            : null,
                   ),
                   TextFormField(
                     controller: costController,
-                    decoration: const InputDecoration(
-                      labelText: 'ต้นทุนเฉลี่ยต่อหน่วย (Avg Cost)',
+                    decoration: InputDecoration(
+                      labelText: l10n.ingredientFieldCostLabel,
                     ),
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                     ),
                     validator: (value) =>
-                        (value?.isEmpty ?? true) ? 'กรุณากรอกต้นทุน' : null,
+                        (value?.isEmpty ?? true)
+                            ? l10n.ingredientFieldCostValidation
+                            : null,
                   ),
                   TextFormField(
                     controller: thresholdController,
-                    decoration: const InputDecoration(
-                      labelText: 'จุดแจ้งเตือนสต็อกต่ำ',
+                    decoration: InputDecoration(
+                      labelText: l10n.ingredientFieldThresholdLabel,
                     ),
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                     ),
                     validator: (value) => (value?.isEmpty ?? true)
-                        ? 'กรุณากรอกจุดแจ้งเตือน'
+                        ? l10n.ingredientFieldThresholdValidation
                         : null,
                   ),
                 ],
@@ -111,7 +129,7 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('ยกเลิก'),
+              child: Text(l10n.commonCancel),
             ),
             ElevatedButton(
               onPressed: () {
@@ -136,7 +154,7 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
                   Navigator.of(context).pop();
                 }
               },
-              child: const Text('บันทึก'),
+              child: Text(l10n.commonSave),
             ),
           ],
         );
@@ -145,16 +163,17 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
   }
 
   void _deleteIngredient(String docId) {
+    final l10n = AppLocalizations.of(context)!;
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('ยืนยันการลบ'),
-          content: const Text('คุณต้องการลบรายการนี้ใช่หรือไม่?'),
+          title: Text(l10n.ingredientDeleteTitle),
+          content: Text(l10n.ingredientDeleteMessage),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('ยกเลิก'),
+              child: Text(l10n.commonCancel),
             ),
             ElevatedButton(
               onPressed: () {
@@ -162,7 +181,7 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
                 Navigator.of(context).pop();
               },
               style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-              child: const Text('ลบ'),
+              child: Text(l10n.commonDelete),
             ),
           ],
         );
@@ -172,14 +191,18 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final currencyProvider = context.watch<CurrencyProvider>();
+    final localeProvider = context.watch<LocaleProvider>();
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('จัดการสต็อกวัตถุดิบ'),
+        title: Text(l10n.ingredientPageTitle),
         // --- 2. Add this actions section ---
         actions: [
           IconButton(
             icon: const Icon(Icons.playlist_add_check_circle_outlined),
-            tooltip: 'Add Purchase Order',
+            tooltip: l10n.ingredientAddPurchaseOrderTooltip,
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute(
@@ -198,10 +221,14 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
             return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
-            return Center(child: Text('เกิดข้อผิดพลาด: ${snapshot.error}'));
+            return Center(
+              child: Text(
+                l10n.ingredientListError('${snapshot.error}'),
+              ),
+            );
           }
           if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return const Center(child: Text('ยังไม่มีวัตถุดิบในระบบ'));
+            return Center(child: Text(l10n.ingredientListEmpty));
           }
 
           final ingredients = snapshot.data!.docs;
@@ -213,15 +240,23 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
               final ingredient = ingredientDoc.data();
               final isLowStock =
                   ingredient.stockQuantity <= ingredient.lowStockThreshold;
+              final quantityDigits =
+                  ingredient.stockQuantity % 1 == 0 ? 0 : 2;
+              final quantityDisplay = localeProvider.formatNumber(
+                ingredient.stockQuantity,
+                decimalDigits: quantityDigits,
+              );
+              final unitLabel = l10n.localizedUnitLabel(ingredient.unit);
+              final avgCostDisplay = currencyProvider.format(ingredient.cost);
+              final subtitleText =
+                  l10n.ingredientSummary(quantityDisplay, unitLabel, avgCostDisplay);
 
               return Card(
                 color: isLowStock ? Colors.red.withAlpha(25) : null,
                 margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 child: ListTile(
                   title: Text(ingredient.name),
-                  subtitle: Text(
-                    'คงเหลือ: ${ingredient.stockQuantity} ${ingredient.unit} (ต้นทุนเฉลี่ย: ${ingredient.cost.toStringAsFixed(2)})',
-                  ),
+                  subtitle: Text(subtitleText),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -244,7 +279,7 @@ class _IngredientManagementPageState extends State<IngredientManagementPage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showIngredientDialog(),
-        tooltip: 'เพิ่มวัตถุดิบใหม่',
+        tooltip: l10n.ingredientFabTooltip,
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,69 @@
+{
+  "@@locale": "en",
+  "appTitle": "Restaurant POS",
+  "languagePickerLabel": "Language",
+  "languagePickerSystem": "System default",
+  "languageEnglish": "English",
+  "languageThai": "Thai",
+  "pinLoginTitle": "Enter PIN",
+  "pinLoginInstructions": "Please enter your 4-digit PIN",
+  "pinLoginInvalidPin": "Invalid PIN. Please try again.",
+  "pinLoginLoginButton": "Login",
+  "checkoutCopyLink": "Copy link",
+  "checkoutCopyLinkSuccess": "Link copied to clipboard",
+  "checkoutAppliedPaymentsTitle": "Applied Payments",
+  "checkoutPaymentUnknownMethod": "Unknown",
+  "checkoutPaymentReference": "Ref: {reference}",
+  "@checkoutPaymentReference": {
+    "placeholders": {
+      "reference": {}
+    }
+  },
+  "ingredientDialogCreateTitle": "Add ingredient",
+  "ingredientDialogEditTitle": "Edit ingredient",
+  "ingredientFieldNameLabel": "Ingredient name",
+  "ingredientFieldNameValidation": "Please enter a name",
+  "ingredientFieldUnitLabel": "Unit (e.g. kg, g, pcs)",
+  "ingredientFieldUnitValidation": "Please enter a unit",
+  "ingredientFieldStockLabel": "Stock quantity",
+  "ingredientFieldStockValidation": "Please enter a quantity",
+  "ingredientFieldCostLabel": "Average cost per unit",
+  "ingredientFieldCostValidation": "Please enter a cost",
+  "ingredientFieldThresholdLabel": "Low stock threshold",
+  "ingredientFieldThresholdValidation": "Please enter a threshold",
+  "commonCancel": "Cancel",
+  "commonSave": "Save",
+  "commonDelete": "Delete",
+  "ingredientDeleteTitle": "Delete ingredient",
+  "ingredientDeleteMessage": "Are you sure you want to delete this item?",
+  "ingredientPageTitle": "Ingredient inventory",
+  "ingredientAddPurchaseOrderTooltip": "Add purchase order",
+  "ingredientListError": "Error: {message}",
+  "@ingredientListError": {
+    "placeholders": {
+      "message": {}
+    }
+  },
+  "ingredientListEmpty": "No ingredients found",
+  "ingredientSummary": "{quantity} {unit} (Avg. cost: {avgCost})",
+  "@ingredientSummary": {
+    "placeholders": {
+      "quantity": {},
+      "unit": {},
+      "avgCost": {}
+    }
+  },
+  "ingredientFabTooltip": "Add ingredient",
+  "unitKilogram": "kg",
+  "unitGram": "g",
+  "unitLiter": "L",
+  "unitMilliliter": "mL",
+  "unitPiece": "pc",
+  "valueWithUnit": "{value} {unit}",
+  "@valueWithUnit": {
+    "placeholders": {
+      "value": {},
+      "unit": {}
+    }
+  }
+}

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -1,0 +1,69 @@
+{
+  "@@locale": "th",
+  "appTitle": "ระบบ POS ร้านอาหาร",
+  "languagePickerLabel": "ภาษา",
+  "languagePickerSystem": "ตามค่าระบบ",
+  "languageEnglish": "อังกฤษ",
+  "languageThai": "ไทย",
+  "pinLoginTitle": "กรอกรหัส PIN",
+  "pinLoginInstructions": "กรุณากรอกรหัส PIN 4 หลัก",
+  "pinLoginInvalidPin": "รหัส PIN ไม่ถูกต้อง กรุณาลองอีกครั้ง",
+  "pinLoginLoginButton": "เข้าสู่ระบบ",
+  "checkoutCopyLink": "คัดลอกลิงก์",
+  "checkoutCopyLinkSuccess": "คัดลอกลิงก์เรียบร้อยแล้ว",
+  "checkoutAppliedPaymentsTitle": "รายการชำระเงินที่ใช้",
+  "checkoutPaymentUnknownMethod": "ไม่ทราบ",
+  "checkoutPaymentReference": "อ้างอิง: {reference}",
+  "@checkoutPaymentReference": {
+    "placeholders": {
+      "reference": {}
+    }
+  },
+  "ingredientDialogCreateTitle": "เพิ่มวัตถุดิบ",
+  "ingredientDialogEditTitle": "แก้ไขวัตถุดิบ",
+  "ingredientFieldNameLabel": "ชื่อวัตถุดิบ",
+  "ingredientFieldNameValidation": "กรุณากรอกชื่อ",
+  "ingredientFieldUnitLabel": "หน่วยนับ (เช่น กก., กรัม, ชิ้น)",
+  "ingredientFieldUnitValidation": "กรุณากรอกหน่วยนับ",
+  "ingredientFieldStockLabel": "จำนวนคงเหลือ",
+  "ingredientFieldStockValidation": "กรุณากรอกจำนวน",
+  "ingredientFieldCostLabel": "ต้นทุนเฉลี่ยต่อหน่วย",
+  "ingredientFieldCostValidation": "กรุณากรอกต้นทุน",
+  "ingredientFieldThresholdLabel": "จุดเตือนสต็อกต่ำ",
+  "ingredientFieldThresholdValidation": "กรุณากรอกจุดเตือน",
+  "commonCancel": "ยกเลิก",
+  "commonSave": "บันทึก",
+  "commonDelete": "ลบ",
+  "ingredientDeleteTitle": "ยืนยันการลบ",
+  "ingredientDeleteMessage": "คุณต้องการลบรายการนี้หรือไม่",
+  "ingredientPageTitle": "จัดการสต็อกวัตถุดิบ",
+  "ingredientAddPurchaseOrderTooltip": "สร้างใบสั่งซื้อ",
+  "ingredientListError": "เกิดข้อผิดพลาด: {message}",
+  "@ingredientListError": {
+    "placeholders": {
+      "message": {}
+    }
+  },
+  "ingredientListEmpty": "ยังไม่มีวัตถุดิบในระบบ",
+  "ingredientSummary": "{quantity} {unit} (ต้นทุนเฉลี่ย: {avgCost})",
+  "@ingredientSummary": {
+    "placeholders": {
+      "quantity": {},
+      "unit": {},
+      "avgCost": {}
+    }
+  },
+  "ingredientFabTooltip": "เพิ่มวัตถุดิบ",
+  "unitKilogram": "กก.",
+  "unitGram": "กรัม",
+  "unitLiter": "ลิตร",
+  "unitMilliliter": "มิลลิลิตร",
+  "unitPiece": "ชิ้น",
+  "valueWithUnit": "{value} {unit}",
+  "@valueWithUnit": {
+    "placeholders": {
+      "value": {},
+      "unit": {}
+    }
+  }
+}

--- a/lib/locale_provider.dart
+++ b/lib/locale_provider.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleProvider extends ChangeNotifier {
+  LocaleProvider() {
+    _loadPreferredLocale();
+  }
+
+  static const _preferenceKey = 'app_locale';
+  SharedPreferences? _preferences;
+  Locale? _locale;
+  bool _initialized = false;
+
+  Locale? get locale => _locale;
+  bool get isInitialized => _initialized;
+
+  Future<void> setLocale(Locale? locale) async {
+    final prefs = await _ensurePreferences();
+    Locale? resolvedLocale;
+    String? storeValue;
+
+    if (locale != null) {
+      final canonical = Intl.canonicalizedLocale(locale.toLanguageTag());
+      storeValue = canonical;
+      resolvedLocale = _localeFromTag(canonical);
+      Intl.defaultLocale = canonical;
+    } else {
+      await prefs.remove(_preferenceKey);
+      Intl.defaultLocale = null;
+    }
+
+    if (storeValue != null) {
+      await prefs.setString(_preferenceKey, storeValue);
+    }
+
+    if (_locale?.toLanguageTag() != resolvedLocale?.toLanguageTag()) {
+      _locale = resolvedLocale;
+      notifyListeners();
+    }
+  }
+
+  NumberFormat decimalFormatter({int? decimalDigits}) {
+    final formatter = NumberFormat.decimalPattern(_effectiveLocaleName);
+    if (decimalDigits != null) {
+      formatter
+        ..minimumFractionDigits = decimalDigits
+        ..maximumFractionDigits = decimalDigits;
+    }
+    return formatter;
+  }
+
+  String formatNumber(num value, {int? decimalDigits}) {
+    return decimalFormatter(decimalDigits: decimalDigits).format(value);
+  }
+
+  String formatValueWithUnit(num value, String unit, {int? decimalDigits}) {
+    final number = formatNumber(value, decimalDigits: decimalDigits);
+    return '$number $unit';
+  }
+
+  Future<void> _loadPreferredLocale() async {
+    final prefs = await _ensurePreferences();
+    final stored = prefs.getString(_preferenceKey);
+    if (stored != null && stored.isNotEmpty) {
+      _locale = _localeFromTag(stored);
+      Intl.defaultLocale = stored;
+    }
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<SharedPreferences> _ensurePreferences() async {
+    if (_preferences != null) {
+      return _preferences!;
+    }
+    _preferences = await SharedPreferences.getInstance();
+    return _preferences!;
+  }
+
+  Locale? _localeFromTag(String tag) {
+    final canonical = Intl.canonicalizedLocale(tag);
+    final segments = canonical.split(RegExp('[-_]'));
+    if (segments.length == 1) {
+      return Locale(segments.first);
+    }
+    return Locale(segments.first, segments[1]);
+  }
+
+  String get _effectiveLocaleName {
+    return _locale?.toLanguageTag() ?? Intl.getCurrentLocale();
+  }
+}

--- a/lib/localization/localization_extensions.dart
+++ b/lib/localization/localization_extensions.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
+
+extension AppLocalizationsX on AppLocalizations {
+  String localizedUnitLabel(String unit) {
+    final normalized = unit.trim().toLowerCase();
+    switch (normalized) {
+      case 'kg':
+      case 'kilogram':
+      case 'kilograms':
+        return unitKilogram;
+      case 'g':
+      case 'gram':
+      case 'grams':
+        return unitGram;
+      case 'l':
+      case 'liter':
+      case 'litre':
+      case 'liters':
+      case 'litres':
+        return unitLiter;
+      case 'ml':
+      case 'milliliter':
+      case 'millilitre':
+      case 'milliliters':
+      case 'millilitres':
+        return unitMilliliter;
+      case 'pc':
+      case 'pcs':
+      case 'piece':
+      case 'pieces':
+        return unitPiece;
+      default:
+        return unit;
+    }
+  }
+
+  String formatValueWithUnit(num value, String unit, {int? decimalDigits}) {
+    final format = NumberFormat.decimalPattern(Intl.getCurrentLocale());
+    if (decimalDigits != null) {
+      format
+        ..minimumFractionDigits = decimalDigits
+        ..maximumFractionDigits = decimalDigits;
+    }
+    final number = format.format(value);
+    return valueWithUnit(number, localizedUnitLabel(unit));
+  }
+
+  String describeLocale(Locale locale) {
+    switch (locale.languageCode) {
+      case 'th':
+        return languageThai;
+      case 'en':
+      default:
+        return languageEnglish;
+    }
+  }
+}

--- a/lib/pin_login_page.dart
+++ b/lib/pin_login_page.dart
@@ -1,10 +1,13 @@
 // lib/pin_login_page.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import 'auth_service.dart';
+import 'widgets/language_picker_button.dart';
+
 class PinLoginPage extends StatefulWidget {
   const PinLoginPage({super.key});
 
@@ -32,7 +35,7 @@ class _PinLoginPageState extends State<PinLoginPage> {
     }
   }
 
-  void _submitPin() async {
+  Future<void> _submitPin() async {
     if (_pin.length != 4) return;
 
     setState(() {
@@ -44,35 +47,43 @@ class _PinLoginPageState extends State<PinLoginPage> {
 
     if (success) {
       if (mounted) context.go('/order-type-selection');
-    } else {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          // <-- FIXED: showSnackBar
-          const SnackBar(
-            // <-- FIXED: SnackBar
-            content: Text('Invalid PIN. Please try again.'),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
-      setState(() {
-        _pin = '';
-        _isLoading = false;
-      });
+      return;
     }
-  } // <-- FIXED: Added missing '}' here
+
+    if (!mounted) {
+      return;
+    }
+
+    final l10n = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(l10n.pinLoginInvalidPin),
+        backgroundColor: Colors.red,
+      ),
+    );
+    setState(() {
+      _pin = '';
+      _isLoading = false;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Enter PIN')),
+      appBar: AppBar(
+        title: Text(l10n.pinLoginTitle),
+        actions: const [LanguagePickerButton()],
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
-              'Please Enter Your 4-Digit PIN',
-              style: TextStyle(fontSize: 18),
+            Text(
+              l10n.pinLoginInstructions,
+              style: const TextStyle(fontSize: 18),
+              textAlign: TextAlign.center,
             ),
             const SizedBox(height: 20),
             Row(
@@ -125,12 +136,10 @@ class _PinLoginPageState extends State<PinLoginPage> {
               width: 300,
               height: 50,
               child: ElevatedButton(
-                onPressed: (_pin.length == 4 && !_isLoading)
-                    ? _submitPin
-                    : null,
+                onPressed: (_pin.length == 4 && !_isLoading) ? _submitPin : null,
                 child: _isLoading
                     ? const CircularProgressIndicator()
-                    : const Text('Login'),
+                    : Text(l10n.pinLoginLoginButton),
               ),
             ),
           ],

--- a/lib/widgets/language_picker_button.dart
+++ b/lib/widgets/language_picker_button.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+
+import '../locale_provider.dart';
+import '../localization/localization_extensions.dart';
+
+class LanguagePickerButton extends StatelessWidget {
+  const LanguagePickerButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final localeProvider = context.watch<LocaleProvider>();
+    final l10n = AppLocalizations.of(context)!;
+    final currentLocale = localeProvider.locale;
+
+    return PopupMenuButton<Locale?>(
+      icon: const Icon(Icons.language),
+      tooltip: l10n.languagePickerLabel,
+      onSelected: (selected) {
+        unawaited(localeProvider.setLocale(selected));
+      },
+      itemBuilder: (context) {
+        final entries = <PopupMenuEntry<Locale?>>[
+          PopupMenuItem<Locale?>(
+            value: null,
+            child: Row(
+              children: [
+                if (currentLocale == null)
+                  const Icon(Icons.check, size: 18)
+                else
+                  const SizedBox(width: 18),
+                const SizedBox(width: 8),
+                Expanded(child: Text(l10n.languagePickerSystem)),
+              ],
+            ),
+          ),
+        ];
+
+        for (final locale in AppLocalizations.supportedLocales) {
+          final isSelected = currentLocale != null &&
+              locale.languageCode == currentLocale.languageCode &&
+              (locale.countryCode?.isEmpty ?? true ||
+                  locale.countryCode == currentLocale.countryCode);
+          entries.add(
+            PopupMenuItem<Locale?>(
+              value: locale,
+              child: Row(
+                children: [
+                  if (isSelected)
+                    const Icon(Icons.check, size: 18)
+                  else
+                    const SizedBox(width: 18),
+                  const SizedBox(width: 8),
+                  Expanded(child: Text(l10n.describeLocale(locale))),
+                ],
+              ),
+            ),
+          );
+        }
+        return entries;
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
   provider: ^6.1.2
   firebase_core: ^3.1.1
   cloud_firestore: ^5.0.2


### PR DESCRIPTION
## Summary
- add flutter localization assets, locale provider, and router configuration to support runtime language switching
- update currency provider and checkout flow to format amounts with the active locale and translations
- localize the ingredient and PIN login experiences, including a reusable language picker button and unit helpers

## Testing
- `flutter pub get` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d560297a848325bb94fe4d594330d7