### PR TITLE
Fix Firestore cache size configuration for new FlutterFire

### DIFF
--- a/lib/background/background_sync.dart
+++ b/lib/background/background_sync.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:isolate';
+import 'dart:ui';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -55,7 +55,7 @@ void backgroundSyncDispatcher() {
       );
       FirebaseFirestore.instance.settings = const Settings(
         persistenceEnabled: true,
-        cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+        cacheSizeBytes: Settings.cacheSizeUnlimited,
       );
       final executor = _BackgroundSyncExecutor(
         firestore: FirebaseFirestore.instance,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -402,7 +402,7 @@ Future<void> main() async {
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   FirebaseFirestore.instance.settings = const Settings(
     persistenceEnabled: true,
-    cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+    cacheSizeBytes: Settings.cacheSizeUnlimited,
   );
   await BackgroundSyncManager.instance.registerPeriodicSync();
   runApp(const MyApp());


### PR DESCRIPTION
## Summary
- update the background sync worker to import dart:ui so PluginUtilities is available
- adjust Firestore cache size configuration to use Settings.cacheSizeUnlimited in both the background worker and the main entrypoint

## Testing
- not run (flutter/dart tooling not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7374ebb1483259236384669f9f9ce