### PR TITLE
Vendor patched workmanager plugin with embedding migration

### DIFF
--- a/packages/workmanager_patched/android/build.gradle
+++ b/packages/workmanager_patched/android/build.gradle
@@ -1,0 +1,55 @@
+group 'dev.fluttercommunity.workmanager'
+version '0.5.2'
+
+buildscript {
+    ext.kotlin_version = '1.8.22'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace 'dev.fluttercommunity.workmanager'
+    compileSdkVersion 34
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 34
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.work:work-runtime-ktx:2.9.0'
+    implementation 'androidx.concurrent:concurrent-futures:1.1.0'
+    implementation 'androidx.startup:startup-runtime:1.1.1'
+}

--- a/packages/workmanager_patched/android/settings.gradle
+++ b/packages/workmanager_patched/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'workmanager_patched'

--- a/packages/workmanager_patched/android/src/main/AndroidManifest.xml
+++ b/packages/workmanager_patched/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.fluttercommunity.workmanager" />

--- a/packages/workmanager_patched/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/packages/workmanager_patched/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -1,0 +1,67 @@
+package dev.fluttercommunity.workmanager
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Worker that bridges the Android WorkManager job to the Dart callback.
+ */
+class BackgroundWorker(appContext: Context, workerParams: WorkerParameters) :
+  Worker(appContext, workerParams) {
+
+  override fun doWork(): Result {
+    val taskName = inputData.getString(WorkmanagerPlugin.KEY_TASK_NAME) ?: return Result.failure()
+    val rawInput = inputData.getString(WorkmanagerPlugin.KEY_INPUT_DATA)
+    val payload = rawInput?.let { decodeJson(it) }
+    return try {
+      val success = WorkmanagerPlugin.executeTask(applicationContext, taskName, payload)
+      if (success) Result.success() else Result.retry()
+    } catch (error: Exception) {
+      Result.retry()
+    }
+  }
+
+  private fun decodeJson(raw: String): Map<String, Any?>? {
+    return try {
+      val json = JSONObject(raw)
+      json.toMap()
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun JSONObject.toMap(): Map<String, Any?> {
+    val map = mutableMapOf<String, Any?>()
+    val iterator = keys()
+    while (iterator.hasNext()) {
+      val key = iterator.next()
+      val value = get(key)
+      map[key] = when (value) {
+        is JSONObject -> value.toMap()
+        is JSONArray -> value.toList()
+        JSONObject.NULL -> null
+        else -> value
+      }
+    }
+    return map
+  }
+
+  private fun JSONArray.toList(): List<Any?> {
+    val list = mutableListOf<Any?>()
+    for (index in 0 until length()) {
+      val value = get(index)
+      list.add(
+        when (value) {
+          is JSONObject -> value.toMap()
+          is JSONArray -> value.toList()
+          JSONObject.NULL -> null
+          else -> value
+        }
+      )
+    }
+    return list
+  }
+}

--- a/packages/workmanager_patched/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/packages/workmanager_patched/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -1,0 +1,320 @@
+package dev.fluttercommunity.workmanager
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.view.FlutterCallbackInformation
+import java.util.HashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Implementation of the Workmanager plugin that targets the Flutter v2 Android embedding.
+ */
+class WorkmanagerPlugin : FlutterPlugin, MethodCallHandler {
+  private lateinit var context: Context
+  private lateinit var channel: MethodChannel
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    context = binding.applicationContext
+    channel = MethodChannel(binding.binaryMessenger, FOREGROUND_CHANNEL)
+    channel.setMethodCallHandler(this)
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+
+  override fun onMethodCall(call: MethodCall, result: Result) {
+    when (call.method) {
+      "initialize" -> handleInitialize(call, result)
+      "registerOneOffTask" -> handleRegisterOneOff(call, result)
+      "registerPeriodicTask" -> handleRegisterPeriodic(call, result)
+      "cancelAll" -> {
+        WorkManager.getInstance(context).cancelAllWork()
+        result.success(null)
+      }
+      "cancelByUniqueName" -> {
+        val name = call.arguments as? String
+        if (name == null) {
+          result.error("argument_error", "Unique name is required", null)
+        } else {
+          WorkManager.getInstance(context).cancelUniqueWork(name)
+          result.success(null)
+        }
+      }
+      "cancelByTag" -> {
+        val tag = call.arguments as? String
+        if (tag == null) {
+          result.error("argument_error", "Tag is required", null)
+        } else {
+          WorkManager.getInstance(context).cancelAllWorkByTag(tag)
+          result.success(null)
+        }
+      }
+      else -> result.notImplemented()
+    }
+  }
+
+  private fun handleInitialize(call: MethodCall, result: Result) {
+    val dispatcherHandle = (call.argument<Number>("dispatcherHandle")?.toLong())
+    if (dispatcherHandle == null || dispatcherHandle == 0L) {
+      result.error("argument_error", "dispatcherHandle is required", null)
+      return
+    }
+    val preferences = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    preferences.edit()
+      .putLong(KEY_CALLBACK_HANDLE, dispatcherHandle)
+      .putBoolean(KEY_DEBUG_MODE, call.argument<Boolean>("isInDebugMode") ?: false)
+      .apply()
+    result.success(true)
+  }
+
+  private fun handleRegisterOneOff(call: MethodCall, result: Result) {
+    val args = call.arguments<Map<String, Any?>>() ?: emptyMap()
+    val uniqueName = args["uniqueName"] as? String
+    val taskName = args["taskName"] as? String
+    if (uniqueName.isNullOrEmpty() || taskName.isNullOrEmpty()) {
+      result.error("argument_error", "uniqueName and taskName are required", null)
+      return
+    }
+    val dataBuilder = androidx.work.Data.Builder()
+    dataBuilder.putString(KEY_TASK_NAME, taskName)
+    val inputData = args["inputData"]
+    if (inputData != null) {
+      dataBuilder.putString(KEY_INPUT_DATA, serializeInputData(inputData))
+    }
+
+    val builder = OneTimeWorkRequestBuilder<BackgroundWorker>()
+      .setInputData(dataBuilder.build())
+
+    parseConstraints(args["constraints"])?.let { builder.setConstraints(it) }
+    val delay = (args["initialDelayMillis"] as? Number)?.toLong()
+    if (delay != null && delay > 0) {
+      builder.setInitialDelay(delay, TimeUnit.MILLISECONDS)
+    }
+
+    parseBackoffPolicy(args["backoffPolicy"])?.let { (policy, duration) ->
+      builder.setBackoffCriteria(policy, duration, TimeUnit.MILLISECONDS)
+    }
+
+    (args["tags"] as? List<*>)
+      ?.mapNotNull { it as? String }
+      ?.forEach { builder.addTag(it) }
+
+    val work = builder.build()
+    val existingPolicy = parseExistingWorkPolicy(args["existingWorkPolicy"])
+    WorkManager.getInstance(context).enqueueUniqueWork(uniqueName, existingPolicy, work)
+    result.success(true)
+  }
+
+  private fun handleRegisterPeriodic(call: MethodCall, result: Result) {
+    val args = call.arguments<Map<String, Any?>>() ?: emptyMap()
+    val uniqueName = args["uniqueName"] as? String
+    val taskName = args["taskName"] as? String
+    val frequencyMillis = (args["frequencyMillis"] as? Number)?.toLong()
+    if (uniqueName.isNullOrEmpty() || taskName.isNullOrEmpty() || frequencyMillis == null) {
+      result.error("argument_error", "uniqueName, taskName and frequency are required", null)
+      return
+    }
+
+    val dataBuilder = androidx.work.Data.Builder()
+    dataBuilder.putString(KEY_TASK_NAME, taskName)
+    val inputData = args["inputData"]
+    if (inputData != null) {
+      dataBuilder.putString(KEY_INPUT_DATA, serializeInputData(inputData))
+    }
+
+    val period = frequencyMillis.coerceAtLeast(MIN_PERIODIC_INTERVAL_MILLIS)
+    val builder = PeriodicWorkRequestBuilder<BackgroundWorker>(
+      period,
+      TimeUnit.MILLISECONDS
+    ).setInputData(dataBuilder.build())
+
+    parseConstraints(args["constraints"])?.let { builder.setConstraints(it) }
+
+    val initialDelay = (args["initialDelayMillis"] as? Number)?.toLong()
+    if (initialDelay != null && initialDelay > 0) {
+      builder.setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
+    }
+
+    parseBackoffPolicy(args["backoffPolicy"])?.let { (policy, duration) ->
+      builder.setBackoffCriteria(policy, duration, TimeUnit.MILLISECONDS)
+    }
+
+    (args["tags"] as? List<*>)
+      ?.mapNotNull { it as? String }
+      ?.forEach { builder.addTag(it) }
+
+    val work = builder.build()
+    val existingPolicy = parseExistingPeriodicPolicy(args["existingWorkPolicy"])
+    WorkManager.getInstance(context).enqueueUniquePeriodicWork(uniqueName, existingPolicy, work)
+    result.success(true)
+  }
+
+  companion object {
+    private const val FOREGROUND_CHANNEL = "plugins.flutter.io/workmanager"
+    private const val BACKGROUND_CHANNEL = "plugins.flutter.io/workmanager_background"
+    private const val PREFS = "dev.fluttercommunity.workmanager.preferences"
+    private const val KEY_CALLBACK_HANDLE = "callback_dispatcher_handle"
+    private const val KEY_DEBUG_MODE = "debug_mode"
+    internal const val KEY_TASK_NAME = "workmanager_task_name"
+    internal const val KEY_INPUT_DATA = "workmanager_input_data"
+    private const val MIN_PERIODIC_INTERVAL_MILLIS = 15L * 60L * 1000L
+
+    @Volatile private var backgroundEngine: FlutterEngine? = null
+    @Volatile private var backgroundChannel: MethodChannel? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    fun getDispatcherHandle(context: Context): Long? {
+      val preferences = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+      val handle = preferences.getLong(KEY_CALLBACK_HANDLE, 0L)
+      return if (handle == 0L) null else handle
+    }
+
+    fun isInDebugMode(context: Context): Boolean {
+      val preferences = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+      return preferences.getBoolean(KEY_DEBUG_MODE, false)
+    }
+
+    @Synchronized
+    fun ensureBackgroundIsolate(context: Context) {
+      if (backgroundEngine != null) {
+        return
+      }
+      val dispatcherHandle = getDispatcherHandle(context)
+        ?: throw IllegalStateException("Workmanager is not initialized. Call initialize before scheduling tasks.")
+      val callbackInfo: FlutterCallbackInformation = FlutterCallbackInformation.lookupCallbackInformation(dispatcherHandle)
+        ?: throw IllegalStateException("Failed to retrieve callback information for handle $dispatcherHandle")
+
+      val loader = FlutterInjector.instance().flutterLoader()
+      if (!loader.initialized()) {
+        loader.startInitialization(context)
+      }
+      loader.ensureInitializationComplete(context, null)
+
+      val engine = FlutterEngine(context.applicationContext)
+      val executor: DartExecutor = engine.dartExecutor
+      val dartCallback = DartExecutor.DartCallback(
+        context.assets,
+        loader.findAppBundlePath(),
+        callbackInfo
+      )
+      executor.executeDartCallback(dartCallback)
+
+      backgroundChannel = MethodChannel(executor.binaryMessenger, BACKGROUND_CHANNEL)
+      backgroundEngine = engine
+    }
+
+    fun executeTask(context: Context, taskName: String, inputData: Map<String, Any?>?): Boolean {
+      ensureBackgroundIsolate(context)
+      val latch = CountDownLatch(1)
+      val success = AtomicBoolean(false)
+      val arguments = HashMap<String, Any?>(2)
+      arguments["taskName"] = taskName
+      if (inputData != null) {
+        arguments["inputData"] = inputData
+      }
+
+      val channel = backgroundChannel
+        ?: throw IllegalStateException("Background channel is not initialized")
+
+      mainHandler.post {
+        channel.invokeMethod(
+          "performTask",
+          arguments,
+          object : MethodChannel.Result {
+            override fun success(result: Any?) {
+              success.set((result as? Boolean) == true)
+              latch.countDown()
+            }
+
+            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+              success.set(false)
+              latch.countDown()
+            }
+
+            override fun notImplemented() {
+              success.set(false)
+              latch.countDown()
+            }
+          }
+        )
+      }
+
+      latch.await(10, TimeUnit.MINUTES)
+      return success.get()
+    }
+
+    private fun serializeInputData(data: Any): String {
+      return when (data) {
+        is Map<*, *> -> JSONObject(data).toString()
+        is Iterable<*> -> JSONArray().apply {
+          data.forEach { put(it) }
+        }.toString()
+        else -> data.toString()
+      }
+    }
+
+    private fun parseConstraints(raw: Any?): Constraints? {
+      if (raw !is Map<*, *>) return null
+      val builder = Constraints.Builder()
+      (raw["requiresCharging"] as? Boolean)?.let { builder.setRequiresCharging(it) }
+      (raw["requiresDeviceIdle"] as? Boolean)?.let { builder.setRequiresDeviceIdle(it) }
+      (raw["requiresBatteryNotLow"] as? Boolean)?.let { builder.setRequiresBatteryNotLow(it) }
+      (raw["requiresStorageNotLow"] as? Boolean)?.let { builder.setRequiresStorageNotLow(it) }
+      when (raw["networkType"] as? String) {
+        "connected" -> builder.setRequiredNetworkType(NetworkType.CONNECTED)
+        "unmetered" -> builder.setRequiredNetworkType(NetworkType.UNMETERED)
+        "notRoaming" -> builder.setRequiredNetworkType(NetworkType.NOT_ROAMING)
+        "metered" -> builder.setRequiredNetworkType(NetworkType.METERED)
+        "notRequired", null -> builder.setRequiredNetworkType(NetworkType.NOT_REQUIRED)
+      }
+      return builder.build()
+    }
+
+    private fun parseBackoffPolicy(raw: Any?): Pair<BackoffPolicy, Long>? {
+      if (raw !is Map<*, *>) return null
+      val policy = when (raw["policy"] as? String) {
+        "linear" -> BackoffPolicy.LINEAR
+        else -> BackoffPolicy.EXPONENTIAL
+      }
+      val delay = (raw["delayMillis"] as? Number)?.toLong() ?: return null
+      return policy to delay
+    }
+
+    private fun parseExistingWorkPolicy(raw: Any?): ExistingWorkPolicy {
+      return when (raw as? String) {
+        "replace" -> ExistingWorkPolicy.REPLACE
+        "append" -> ExistingWorkPolicy.APPEND
+        else -> ExistingWorkPolicy.KEEP
+      }
+    }
+
+    private fun parseExistingPeriodicPolicy(raw: Any?): ExistingPeriodicWorkPolicy {
+      return when (raw as? String) {
+        "replace" -> ExistingPeriodicWorkPolicy.REPLACE
+        else -> ExistingPeriodicWorkPolicy.KEEP
+      }
+    }
+  }
+}

--- a/packages/workmanager_patched/lib/workmanager.dart
+++ b/packages/workmanager_patched/lib/workmanager.dart
@@ -1,0 +1,212 @@
+library workmanager;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+const MethodChannel _foregroundChannel = MethodChannel('plugins.flutter.io/workmanager');
+const MethodChannel _backgroundChannel =
+    MethodChannel('plugins.flutter.io/workmanager_background');
+
+/// Signature used when handling background work that was dispatched by the
+/// native Android WorkManager.
+typedef WorkmanagerTaskHandler = FutureOr<bool> Function(
+  String taskName,
+  Map<String, dynamic>? inputData,
+);
+
+WorkmanagerTaskHandler? _taskHandler;
+
+/// Registry that keeps the current task handler.
+Future<dynamic> _backgroundChannelHandler(MethodCall call) async {
+  if (call.method != 'performTask') {
+    throw PlatformException(
+      code: 'unimplemented',
+      message: 'Method \'${call.method}\' is not supported on the background channel.',
+    );
+  }
+  if (_taskHandler == null) {
+    return false;
+  }
+  final arguments = Map<String, dynamic>.from(call.arguments as Map<dynamic, dynamic>);
+  final task = arguments['taskName'] as String?;
+  final rawInput = arguments['inputData'];
+  Map<String, dynamic>? input;
+  if (rawInput is Map) {
+    input = Map<String, dynamic>.from(rawInput.cast<dynamic, dynamic>());
+  } else if (rawInput is String && rawInput.isNotEmpty) {
+    try {
+      final decoded = json.decode(rawInput);
+      if (decoded is Map<String, dynamic>) {
+        input = decoded;
+      }
+    } on FormatException {
+      // Ignore invalid payloads and keep [input] null.
+    }
+  }
+  if (task == null) {
+    return false;
+  }
+  final result = await _taskHandler!.call(task, input);
+  return result == true;
+}
+
+/// A Dart wrapper around the platform Workmanager implementation.
+class Workmanager {
+  factory Workmanager() => _instance;
+
+  Workmanager._internal() {
+    // Ensure the background channel is configured when the library is loaded.
+    _backgroundChannel.setMethodCallHandler(_backgroundChannelHandler);
+  }
+
+  static final Workmanager _instance = Workmanager._internal();
+
+  /// Initializes the background dispatcher entry-point on the native side.
+  Future<bool> initialize(
+    Function callbackDispatcher, {
+    bool isInDebugMode = false,
+  }) async {
+    final callbackHandle = PluginUtilities.getCallbackHandle(callbackDispatcher);
+    if (callbackHandle == null) {
+      throw ArgumentError(
+        'Failed to obtain a callback handle for the provided dispatcher.',
+      );
+    }
+    final result = await _foregroundChannel.invokeMethod<bool>('initialize', <String, dynamic>{
+      'dispatcherHandle': callbackHandle.toRawHandle(),
+      'isInDebugMode': isInDebugMode,
+    });
+    return result ?? false;
+  }
+
+  /// Registers the Dart [handler] to be invoked for background tasks.
+  void executeTask(WorkmanagerTaskHandler handler) {
+    _taskHandler = handler;
+  }
+
+  /// Registers a one-off task with the underlying WorkManager instance.
+  Future<bool> registerOneOffTask(
+    String uniqueName,
+    String taskName, {
+    Map<String, dynamic>? inputData,
+    Duration? initialDelay,
+    Constraints? constraints,
+    ExistingWorkPolicy existingWorkPolicy = ExistingWorkPolicy.keep,
+    BackoffPolicyConfig? backoffPolicy,
+    List<String>? tags,
+  }) async {
+    final result = await _foregroundChannel.invokeMethod<bool>('registerOneOffTask', <String, dynamic>{
+      'uniqueName': uniqueName,
+      'taskName': taskName,
+      'inputData': inputData,
+      'initialDelayMillis': initialDelay?.inMilliseconds,
+      'existingWorkPolicy': describeEnum(existingWorkPolicy),
+      'constraints': constraints?.toJson(),
+      'backoffPolicy': backoffPolicy?.toJson(),
+      'tags': tags,
+    });
+    return result ?? false;
+  }
+
+  /// Registers a periodic task with the underlying WorkManager instance.
+  Future<bool> registerPeriodicTask(
+    String uniqueName,
+    String taskName, {
+    required Duration frequency,
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+    ExistingWorkPolicy existingWorkPolicy = ExistingWorkPolicy.keep,
+    BackoffPolicyConfig? backoffPolicy,
+    List<String>? tags,
+  }) async {
+    final result = await _foregroundChannel.invokeMethod<bool>('registerPeriodicTask', <String, dynamic>{
+      'uniqueName': uniqueName,
+      'taskName': taskName,
+      'frequencyMillis': frequency.inMilliseconds,
+      'initialDelayMillis': initialDelay?.inMilliseconds,
+      'inputData': inputData,
+      'constraints': constraints?.toJson(),
+      'existingWorkPolicy': describeEnum(existingWorkPolicy),
+      'backoffPolicy': backoffPolicy?.toJson(),
+      'tags': tags,
+    });
+    return result ?? false;
+  }
+
+  /// Cancels all enqueued work.
+  Future<void> cancelAll() => _foregroundChannel.invokeMethod<void>('cancelAll');
+
+  /// Cancels work identified by [uniqueName].
+  Future<void> cancelByUniqueName(String uniqueName) =>
+      _foregroundChannel.invokeMethod<void>('cancelByUniqueName', uniqueName);
+
+  /// Cancels work matching the provided [tag].
+  Future<void> cancelByTag(String tag) =>
+      _foregroundChannel.invokeMethod<void>('cancelByTag', tag);
+}
+
+/// Defines how existing work should be treated when scheduling.
+enum ExistingWorkPolicy {
+  replace,
+  keep,
+  append,
+}
+
+/// Specifies the network requirements for the scheduled task.
+enum NetworkType {
+  notRequired,
+  connected,
+  unmetered,
+  notRoaming,
+  metered,
+}
+
+/// Configuration for retry backoff policies.
+class BackoffPolicyConfig {
+  const BackoffPolicyConfig({
+    required this.policy,
+    required this.delay,
+  });
+
+  final BackoffPolicy policy;
+  final Duration delay;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'policy': describeEnum(policy),
+        'delayMillis': delay.inMilliseconds,
+      };
+}
+
+enum BackoffPolicy {
+  exponential,
+  linear,
+}
+
+/// Constraints used when scheduling tasks.
+class Constraints {
+  const Constraints({
+    this.requiresCharging,
+    this.requiresDeviceIdle,
+    this.requiresBatteryNotLow,
+    this.requiresStorageNotLow,
+    this.networkType,
+  });
+
+  final bool? requiresCharging;
+  final bool? requiresDeviceIdle;
+  final bool? requiresBatteryNotLow;
+  final bool? requiresStorageNotLow;
+  final NetworkType? networkType;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (requiresCharging != null) 'requiresCharging': requiresCharging,
+        if (requiresDeviceIdle != null) 'requiresDeviceIdle': requiresDeviceIdle,
+        if (requiresBatteryNotLow != null) 'requiresBatteryNotLow': requiresBatteryNotLow,
+        if (requiresStorageNotLow != null) 'requiresStorageNotLow': requiresStorageNotLow,
+        if (networkType != null) 'networkType': describeEnum(networkType!),
+      };
+}

--- a/packages/workmanager_patched/pubspec.yaml
+++ b/packages/workmanager_patched/pubspec.yaml
@@ -1,0 +1,16 @@
+name: workmanager_patched
+version: 0.5.2+1
+description: "Patched local copy of the workmanager plugin vendored for migration."
+homepage: https://github.com/fluttercommunity/flutter_workmanager
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.3.0"
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: dev.fluttercommunity.workmanager
+        pluginClass: WorkmanagerPlugin

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1116,11 +1116,10 @@ packages:
   workmanager:
     dependency: "direct main"
     description:
-      name: workmanager
-      sha256: ed13530cccd28c5c9959ad42d657cd0666274ca74c56dea0ca183ddd527d3a00
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.2"
+      path: "packages/workmanager_patched"
+      relative: true
+    source: path
+    version: "0.5.2+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,8 @@ dependencies:
   google_fonts: ^5.0.0
   flutter_slidable: ^3.0.0
   cryptography: ^2.7.0
-  workmanager: ^0.5.2
+  workmanager:
+    path: packages/workmanager_patched
 
   
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- vendor a local `workmanager_patched` package based on 0.5.2 so the plugin source can be customized
- migrate the Android implementation to the Flutter v2 embedding with a new `WorkmanagerPlugin` and updated `BackgroundWorker`
- expose a patched Dart API and point the app to the local package via a `path` override

## Testing
- `flutter pub get` *(fails: flutter tool not available in execution environment)*
- `flutter build apk` *(fails: flutter tool not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1ece766c8325b4ee9de2f7e2fa89