### PR TITLE
feat: add global error logging and remote kill switch

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,6 +12,12 @@ service cloud.firestore {
         request.auth.token.tenantId == tenantId;
     }
 
+    function orderTenantMatches(orderId) {
+      return orderId is string && orderId != '' &&
+        exists(/databases/$(database)/documents/orders/$(orderId)) &&
+        tenantMatches(get(/databases/$(database)/documents/orders/$(orderId)).data.tenantId);
+    }
+
     match /auditLogs/{logId} {
       allow read: if tenantMatches(resource.data.tenantId);
       allow write: if false;
@@ -19,6 +25,18 @@ service cloud.firestore {
 
     match /featureFlags/{tenantId} {
       allow read, write: if tenantMatches(tenantId);
+    }
+
+    match /opsLogs/{logId} {
+      allow create: if request.auth != null;
+      allow read, update, delete: if false;
+    }
+
+    match /refunds/{refundId} {
+      allow read: if hasTenant() && orderTenantMatches(resource.data.originalOrderId);
+      allow create: if hasTenant() &&
+        orderTenantMatches(request.resource.data.originalOrderId);
+      allow update, delete: if false;
     }
 
     match /{document=**} {

--- a/lib/services/app_availability_service.dart
+++ b/lib/services/app_availability_service.dart
@@ -1,0 +1,72 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/foundation.dart';
+
+import 'ops_observability_service.dart';
+
+enum AppAvailabilityStatus { checking, available, blocked }
+
+class AppAvailabilityService extends ChangeNotifier {
+  AppAvailabilityService(
+    this._remoteConfig,
+    this._observability,
+    this._buildNumber,
+  );
+
+  final FirebaseRemoteConfig _remoteConfig;
+  final OpsObservabilityService _observability;
+  final String _buildNumber;
+
+  AppAvailabilityStatus _status = AppAvailabilityStatus.checking;
+  String? _message;
+
+  AppAvailabilityStatus get status => _status;
+  String? get message => _message;
+
+  Future<void> initialize() async {
+    try {
+      await _remoteConfig.ensureInitialized();
+      await _remoteConfig.setConfigSettings(RemoteConfigSettings(
+        fetchTimeout: const Duration(seconds: 10),
+        minimumFetchInterval: const Duration(minutes: 5),
+      ));
+      await _remoteConfig.setDefaults(const {
+        'minimum_supported_build': 1,
+        'kill_switch_enabled': false,
+        'kill_switch_message': '',
+      });
+
+      await _remoteConfig.fetchAndActivate();
+
+      final bool killSwitchEnabled =
+          _remoteConfig.getBool('kill_switch_enabled');
+      final int minimumSupportedBuild =
+          _remoteConfig.getInt('minimum_supported_build');
+      final String configuredMessage =
+          _remoteConfig.getString('kill_switch_message').trim();
+
+      final int currentBuild = int.tryParse(_buildNumber) ?? 0;
+
+      if (killSwitchEnabled && currentBuild < minimumSupportedBuild) {
+        _status = AppAvailabilityStatus.blocked;
+        _message = configuredMessage.isNotEmpty
+            ? configuredMessage
+            : 'This version of the app is no longer supported. '
+                'Please update to continue using the service.';
+      } else {
+        _status = AppAvailabilityStatus.available;
+        _message = null;
+      }
+    } catch (error, stackTrace) {
+      await _observability.log(
+        'Failed to evaluate Remote Config kill switch',
+        level: OpsLogLevel.error,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      _status = AppAvailabilityStatus.available;
+      _message = null;
+    }
+
+    notifyListeners();
+  }
+}

--- a/lib/widgets/app_blocked_screen.dart
+++ b/lib/widgets/app_blocked_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class AppBlockedScreen extends StatelessWidget {
+  const AppBlockedScreen({super.key, this.message});
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final effectiveMessage = message ??
+        'This version of the app has been disabled. Please update to continue.';
+
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Card(
+            elevation: 6,
+            margin: const EdgeInsets.symmetric(horizontal: 24),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.warning_amber_rounded,
+                        size: 36,
+                        color: theme.colorScheme.error,
+                      ),
+                      const SizedBox(width: 12),
+                      Flexible(
+                        child: Text(
+                          'Update Required',
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            color: theme.colorScheme.error,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    effectiveMessage,
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.system_update),
+                    label: const Text('Check for updates'),
+                    onPressed: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                            'Please update the application from your app store or deployment channel.',
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   printing: ^5.12.0
   go_router: ^14.2.0
   url_strategy: ^0.2.0
+  firebase_remote_config: ^5.0.3
   firebase_storage: ^12.1.0
   cloud_functions: ^5.0.3
   image_picker: ^1.1.2
@@ -72,6 +73,7 @@ dependencies:
   collection: ^1.18.0
   restaurant_models:
     path: packages/restaurant_models
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a global error boundary that logs unhandled exceptions to ops observability
- introduce a Remote Config–backed availability service and kill-switch screen for outdated builds
- tighten Firestore security to block client edits of refund documents and permit safe ops logging
- add firebase_remote_config and package_info_plus dependencies for configuration and build metadata

## Testing
- ⚠️ `flutter pub get` *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da634325588325a850fa592e6449bf