### PR TITLE
Add accessibility controls and toast system

### DIFF
--- a/lib/accessibility_provider.dart
+++ b/lib/accessibility_provider.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AccessibilityProvider with ChangeNotifier {
+  AccessibilityProvider() {
+    _load();
+  }
+
+  static const _prefsLargeTextKey = 'accessibility.largeText';
+  static const _prefsHighContrastKey = 'accessibility.highContrast';
+
+  bool _largeText = false;
+  bool _highContrast = false;
+
+  bool get largeText => _largeText;
+  bool get highContrast => _highContrast;
+
+  double get textScaleFactor => _largeText ? 1.2 : 1.0;
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _largeText = prefs.getBool(_prefsLargeTextKey) ?? false;
+    _highContrast = prefs.getBool(_prefsHighContrastKey) ?? false;
+    notifyListeners();
+  }
+
+  Future<void> setLargeText(bool value) async {
+    if (_largeText == value) {
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    _largeText = value;
+    await prefs.setBool(_prefsLargeTextKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setHighContrast(bool value) async {
+    if (_highContrast == value) {
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    _highContrast = value;
+    await prefs.setBool(_prefsHighContrastKey, value);
+    notifyListeners();
+  }
+
+  void toggleLargeText() {
+    setLargeText(!_largeText);
+  }
+
+  void toggleHighContrast() {
+    setHighContrast(!_highContrast);
+  }
+}

--- a/lib/add_purchase_order_page.dart
+++ b/lib/add_purchase_order_page.dart
@@ -4,6 +4,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:restaurant_models/restaurant_models.dart';
+
+import 'widgets/app_snack_bar.dart';
 // Helper class for a line item in the PO
 class PurchaseOrderItem {
   Ingredient ingredient;
@@ -85,12 +87,7 @@ class _AddPurchaseOrderPageState extends State<AddPurchaseOrderPage> {
   // Notice context is now passed into this function
   Future<void> _savePurchaseOrder(BuildContext scaffoldContext) async {
     if (_supplierController.text.isEmpty || _poItems.isEmpty) {
-      ScaffoldMessenger.of(scaffoldContext).showSnackBar(
-        const SnackBar(
-          content: Text('Please fill in supplier and add at least one item.'),
-          backgroundColor: Colors.red,
-        ),
-      );
+      AppSnackBar.showError('Please fill in supplier and add at least one item.');
       return;
     }
 
@@ -105,14 +102,7 @@ class _AddPurchaseOrderPageState extends State<AddPurchaseOrderPage> {
       final quantity = double.tryParse(item.quantityController.text) ?? 0;
       final cost = double.tryParse(item.costController.text) ?? 0;
       if (quantity <= 0 || cost <= 0) {
-        ScaffoldMessenger.of(scaffoldContext).showSnackBar(
-          const SnackBar(
-            content: Text(
-              'Please enter valid quantity and cost for all items.',
-            ),
-            backgroundColor: Colors.red,
-          ),
-        );
+        AppSnackBar.showError('Please enter valid quantity and cost for all items.');
         setState(() {
           _isLoading = false;
         });
@@ -137,22 +127,12 @@ class _AddPurchaseOrderPageState extends State<AddPurchaseOrderPage> {
       });
 
       if (mounted) {
-        ScaffoldMessenger.of(scaffoldContext).showSnackBar(
-          const SnackBar(
-            content: Text('Purchase Order saved successfully!'),
-            backgroundColor: Colors.green,
-          ),
-        );
+        AppSnackBar.showSuccess('Purchase Order saved successfully!');
         Navigator.of(context).pop();
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(scaffoldContext).showSnackBar(
-          SnackBar(
-            content: Text('Failed to save PO: $e'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        AppSnackBar.showError('Failed to save PO: $e');
       }
     } finally {
       if (mounted) {

--- a/lib/clock_in_out_page.dart
+++ b/lib/clock_in_out_page.dart
@@ -4,6 +4,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:restaurant_models/restaurant_models.dart';
+
+import 'widgets/app_snack_bar.dart';
 class ClockInOutPage extends StatefulWidget {
   const ClockInOutPage({super.key});
 
@@ -66,9 +68,7 @@ class _ClockInOutPageState extends State<ClockInOutPage> {
                         .doc(latestRecord.id)
                         .update({'clockOutTime': Timestamp.now()});
 
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('${employee.name} clocked out.')),
-                    );
+                    AppSnackBar.showSuccess('${employee.name} clocked out.');
                   } else {
                     await _firestore.collection('time_records').add({
                       'employeeId': employee.id,
@@ -77,24 +77,15 @@ class _ClockInOutPageState extends State<ClockInOutPage> {
                       'clockOutTime': null,
                     });
 
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('${employee.name} clocked in.')),
-                    );
+                    AppSnackBar.showSuccess('${employee.name} clocked in.');
                   }
 
                   setState(() {});
                 } catch (e) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text('Error: $e'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
+                  AppSnackBar.showError('Error: $e');
                 }
               } else {
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(const SnackBar(content: Text('Invalid PIN!')));
+                AppSnackBar.showError('Invalid PIN!');
               }
             },
             child: const Text('Confirm'),

--- a/lib/customer_lookup_page.dart
+++ b/lib/customer_lookup_page.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart'; // <-- Import intl for date formatting
 import 'package:restaurant_models/restaurant_models.dart';
+
+import 'widgets/app_snack_bar.dart';
 class CustomerLookupPage extends StatefulWidget {
   const CustomerLookupPage({super.key});
 
@@ -94,9 +96,7 @@ class _CustomerLookupPageState extends State<CustomerLookupPage> {
         }
       } catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Failed to create customer: $e')),
-          );
+          AppSnackBar.showError('Failed to create customer: $e');
         }
       } finally {
         if (mounted) {

--- a/lib/customer_menu_page.dart
+++ b/lib/customer_menu_page.dart
@@ -8,6 +8,7 @@ import 'package:restaurant_models/restaurant_models.dart';
 import 'cart_provider.dart';
 import 'customer_checkout_page.dart';
 import 'services/menu_cache_provider.dart';
+import 'widgets/app_snack_bar.dart';
 class CustomerMenuPage extends StatefulWidget {
   final String tableNumber;
 
@@ -72,12 +73,7 @@ class _CustomerMenuPageState extends State<CustomerMenuPage> {
         _tempCart[product.id] = CartItem(product: product);
       }
     });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('${product.name} added to cart.'),
-        duration: const Duration(seconds: 1),
-      ),
-    );
+    AppSnackBar.showSuccess('${product.name} added to cart.');
   }
 
   void _incrementCartItem(String productId) {
@@ -112,9 +108,7 @@ class _CustomerMenuPageState extends State<CustomerMenuPage> {
 
     if (promoQuery.docs.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("Invalid or inactive code.")),
-        );
+        AppSnackBar.showError('Invalid or inactive code.');
       }
       return;
     }
@@ -135,9 +129,7 @@ class _CustomerMenuPageState extends State<CustomerMenuPage> {
 
     if (validationMessage != null) {
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(validationMessage)));
+        AppSnackBar.showError(validationMessage);
       }
       return;
     }

--- a/lib/menu_panel.dart
+++ b/lib/menu_panel.dart
@@ -8,6 +8,7 @@ import 'cart_provider.dart';
 import 'localization/app_localizations.dart';
 import 'services/menu_cache_provider.dart';
 import 'stock_provider.dart';
+import 'widgets/app_snack_bar.dart';
 class MenuPanel extends StatefulWidget {
   const MenuPanel({super.key});
 
@@ -130,13 +131,7 @@ class _MenuPanelState extends State<MenuPanel> {
                             ? () {
                                 final success = cart.addItem(product);
                                 if (!success) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                      content: Text('สินค้าในสต็อกไม่เพียงพอ!'),
-                                      backgroundColor: Colors.red,
-                                      duration: Duration(seconds: 2),
-                                    ),
-                                  );
+                                  AppSnackBar.showError('สินค้าในสต็อกไม่เพียงพอ!');
                                 }
                               }
                             : null,

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../accessibility_provider.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static ThemeData light(AccessibilityProvider accessibility) {
+    final colorScheme = accessibility.highContrast
+        ? ColorScheme.highContrastLight(primary: Colors.indigo)
+        : ColorScheme.fromSeed(seedColor: Colors.indigo);
+    final base = ThemeData(
+      brightness: Brightness.light,
+      colorScheme: colorScheme,
+      useMaterial3: true,
+    );
+    return _applyShared(base, accessibility);
+  }
+
+  static ThemeData dark(AccessibilityProvider accessibility) {
+    final colorScheme = accessibility.highContrast
+        ? ColorScheme.highContrastDark(primary: Colors.indigo)
+        : ColorScheme.fromSeed(
+            seedColor: Colors.indigo,
+            brightness: Brightness.dark,
+          );
+    final base = ThemeData(
+      brightness: Brightness.dark,
+      colorScheme: colorScheme,
+      useMaterial3: true,
+    );
+    return _applyShared(base, accessibility);
+  }
+
+  static ThemeData _applyShared(
+    ThemeData base,
+    AccessibilityProvider accessibility,
+  ) {
+    final scale = accessibility.largeText ? 1.08 : 1.0;
+    final textTheme = base.textTheme.apply(fontSizeFactor: scale);
+    return base.copyWith(
+      textTheme: textTheme,
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: base.colorScheme.inverseSurface,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(
+          color: base.colorScheme.onInverseSurface,
+        ),
+        actionTextColor: base.colorScheme.inversePrimary,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+      appBarTheme: base.appBarTheme.copyWith(
+        titleTextStyle: textTheme.titleLarge?.copyWith(
+          color: base.colorScheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      floatingActionButtonTheme: base.floatingActionButtonTheme.copyWith(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/accessibility_overlay.dart
+++ b/lib/widgets/accessibility_overlay.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../accessibility_provider.dart';
+import 'responsive/responsive_tokens.dart';
+
+class AccessibilityOverlayHost extends StatefulWidget {
+  const AccessibilityOverlayHost({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<AccessibilityOverlayHost> createState() => _AccessibilityOverlayHostState();
+}
+
+class _AccessibilityOverlayHostState extends State<AccessibilityOverlayHost> {
+  bool _panelVisible = false;
+
+  void _togglePanel() {
+    setState(() {
+      _panelVisible = !_panelVisible;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        widget.child,
+        Align(
+          alignment: Alignment.bottomLeft,
+          child: SafeArea(
+            minimum: ResponsiveTokens.edgeInsetsSmall,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_panelVisible)
+                  _AccessibilityPanel(onClose: _togglePanel),
+                FloatingActionButton.small(
+                  heroTag: '_a11y_toggle',
+                  onPressed: _togglePanel,
+                  tooltip: 'Accessibility',
+                  child: Icon(_panelVisible ? Icons.visibility_off : Icons.visibility),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AccessibilityPanel extends StatelessWidget {
+  const _AccessibilityPanel({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = ResponsiveTokens.of(context);
+    final accessibility = context.watch<AccessibilityProvider>();
+    final theme = Theme.of(context);
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxWidth: tokens.overlayWidth,
+      ),
+      child: Material(
+        elevation: 6,
+        borderRadius: BorderRadius.circular(tokens.radiusMedium),
+        clipBehavior: Clip.antiAlias,
+        color: theme.colorScheme.surface,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              color: theme.colorScheme.primaryContainer,
+              padding: tokens.paddingMedium,
+              child: Row(
+                children: [
+                  Icon(Icons.accessibility_new, color: theme.colorScheme.onPrimaryContainer),
+                  tokens.gapSmall,
+                  Expanded(
+                    child: Text(
+                      'Accessibility',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: theme.colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: onClose,
+                    tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: tokens.paddingMedium,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SwitchListTile(
+                    value: accessibility.largeText,
+                    onChanged: (value) => accessibility.setLargeText(value),
+                    title: const Text('Large text'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  SwitchListTile(
+                    value: accessibility.highContrast,
+                    onChanged: (value) => accessibility.setHighContrast(value),
+                    title: const Text('High contrast mode'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/app_snack_bar.dart
+++ b/lib/widgets/app_snack_bar.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+enum AppSnackBarType { info, success, warning, error }
+
+class AppSnackBar {
+  AppSnackBar._();
+
+  static final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+  static void show(
+    String message, {
+    AppSnackBarType type = AppSnackBarType.info,
+    VoidCallback? onUndo,
+    String? undoLabel,
+    Duration duration = const Duration(seconds: 4),
+  }) {
+    final messenger = messengerKey.currentState;
+    if (messenger == null) {
+      return;
+    }
+
+    final theme = Theme.of(messenger.context);
+    final colorScheme = theme.colorScheme;
+
+    Color? background;
+    Color? textColor;
+
+    switch (type) {
+      case AppSnackBarType.info:
+        background = colorScheme.inverseSurface;
+        textColor = colorScheme.onInverseSurface;
+        break;
+      case AppSnackBarType.success:
+        background = colorScheme.tertiaryContainer;
+        textColor = colorScheme.onTertiaryContainer;
+        break;
+      case AppSnackBarType.warning:
+        background = colorScheme.errorContainer;
+        textColor = colorScheme.onErrorContainer;
+        break;
+      case AppSnackBarType.error:
+        background = colorScheme.error;
+        textColor = colorScheme.onError;
+        break;
+    }
+
+    messenger
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            message,
+            style: theme.textTheme.bodyMedium?.copyWith(color: textColor),
+          ),
+          backgroundColor: background,
+          behavior: SnackBarBehavior.floating,
+          duration: duration,
+          action: onUndo != null
+              ? SnackBarAction(
+                  label: undoLabel ?? 'Undo',
+                  onPressed: onUndo,
+                )
+              : null,
+        ),
+      );
+  }
+
+  static void showSuccess(String message, {VoidCallback? onUndo, String? undoLabel}) {
+    show(
+      message,
+      type: AppSnackBarType.success,
+      onUndo: onUndo,
+      undoLabel: undoLabel,
+    );
+  }
+
+  static void showInfo(String message, {VoidCallback? onUndo, String? undoLabel}) {
+    show(
+      message,
+      type: AppSnackBarType.info,
+      onUndo: onUndo,
+      undoLabel: undoLabel,
+    );
+  }
+
+  static void showError(String message) {
+    show(
+      message,
+      type: AppSnackBarType.error,
+      duration: const Duration(seconds: 6),
+    );
+  }
+}

--- a/lib/widgets/ops_debug_overlay.dart
+++ b/lib/widgets/ops_debug_overlay.dart
@@ -1,8 +1,11 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/ops_observability_service.dart';
 import '../services/sync_queue_service.dart';
+import 'responsive/responsive_tokens.dart';
 class OpsDebugOverlayHost extends StatelessWidget {
   const OpsDebugOverlayHost({required this.child, super.key});
 
@@ -58,19 +61,23 @@ class _OpsDebugOverlay extends StatelessWidget {
           return IgnorePointer(ignoring: false, child: handle);
         }
 
+        final tokens = ResponsiveTokens.of(context);
+
         return Stack(
           children: [
             handle,
             Align(
               alignment: Alignment.bottomRight,
               child: SafeArea(
-                minimum: const EdgeInsets.all(12),
-                child: SizedBox(
-                  width: 360,
-                  height: 320,
+                minimum: ResponsiveTokens.edgeInsetsSmall,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: tokens.overlayWidth,
+                    maxHeight: math.max(240, MediaQuery.sizeOf(context).height * 0.45),
+                  ),
                   child: Material(
                     elevation: 12,
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(tokens.radiusMedium),
                     clipBehavior: Clip.antiAlias,
                     color: theme.colorScheme.surface,
                     child: Column(

--- a/lib/widgets/responsive/responsive_tokens.dart
+++ b/lib/widgets/responsive/responsive_tokens.dart
@@ -1,0 +1,39 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class ResponsiveTokens {
+  const ResponsiveTokens._(this._size);
+
+  factory ResponsiveTokens.of(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    return ResponsiveTokens._(size);
+  }
+
+  final Size _size;
+
+  static const EdgeInsets edgeInsetsSmall = EdgeInsets.all(12);
+
+  double get overlayWidth {
+    final width = _size.width;
+    if (width >= 1440) {
+      return 420;
+    }
+    if (width >= 1024) {
+      return 360;
+    }
+    if (width >= 600) {
+      return 320;
+    }
+    return math.max(240, width - 48);
+  }
+
+  EdgeInsets get paddingMedium => const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 12,
+      );
+
+  double get radiusMedium => 12;
+
+  SizedBox get gapSmall => const SizedBox(width: 12);
+}


### PR DESCRIPTION
## Summary
- add persisted accessibility provider with overlay controls for large text and high-contrast modes wired into the app theme
- introduce responsive layout tokens for shared overlays and adopt them in ops debugging UI
- create centralized AppSnackBar service and migrate key flows to the shared toast pattern while updating theming for consistency

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da7594f31c832587ed9655379f7c3f