### PR TITLE
Add emulator fixtures, typed Firestore helpers, and perf telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,42 @@ npm run test:emulator
 ```
 
 Without the emulator the integration suite is skipped during `npm test`.
+
+## QA Emulator Fixtures
+
+Spin up the Firebase emulator suite and populate it with curated demo data in a
+single command:
+
+```bash
+npm --prefix functions run seed:emulator
+```
+
+By default the script targets `localhost:8080` with the `demo-test` project ID.
+Override `FIRESTORE_EMULATOR_HOST`, `PROJECT_ID` or set `RESET=true` to wipe the
+existing collections before seeding.
+
+## Typed Firestore accessors
+
+The app now exposes strongly-typed Firestore collections via
+`lib/services/firestore_converters.dart`. Providers such as the menu cache,
+retail POS and store service consume these converters to remove manual JSON
+mapping and catch schema drift at compile time.
+
+## Build & performance telemetry
+
+Frame build/raster metrics are sampled at runtime and streamed to BigQuery via
+the callable Cloud Function `ingestBuildMetric`. Configure the destination table
+with the `BUILD_METRICS_DATASET` and `BUILD_METRICS_TABLE` environment variables
+when deploying Cloud Functions.
+
+## Git hooks
+
+Install the project hooks to automatically format, analyze and run targeted
+tests on staged Dart files before every commit:
+
+```bash
+./tool/install_git_hooks.sh
+```
+
+The hook formats staged Dart files, runs `dart analyze` for the impacted
+packages, and executes the relevant `flutter test`/`dart test` targets.

--- a/functions/fixtures/seed-data.json
+++ b/functions/fixtures/seed-data.json
@@ -1,0 +1,102 @@
+{
+  "collections": [
+    {
+      "name": "stores",
+      "documents": [
+        {
+          "id": "demo-store",
+          "data": {
+            "name": "Demo Bistro",
+            "address": "123 Market Street",
+            "tenantId": "demo-tenant",
+            "timezone": "Asia/Bangkok",
+            "isActive": true,
+            "currencySettings": {
+              "code": "THB",
+              "symbol": "฿",
+              "decimalDigits": 2
+            },
+            "release": {
+              "environment": "staging",
+              "channel": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "menu_items",
+      "documents": [
+        {
+          "id": "pad-thai",
+          "data": {
+            "name": "Pad Thai",
+            "category": "mains",
+            "price": 120,
+            "productType": "food",
+            "trackStock": true,
+            "barcode": "000000000001",
+            "modifierGroupIds": ["spice-level"],
+            "kitchenStations": ["wok"],
+            "prepTimeMinutes": 10
+          }
+        },
+        {
+          "id": "iced-tea",
+          "data": {
+            "name": "Thai Iced Tea",
+            "category": "drinks",
+            "price": 65,
+            "productType": "general",
+            "trackStock": true,
+            "barcode": "000000000002",
+            "kitchenStations": ["bar"],
+            "prepTimeMinutes": 3
+          }
+        }
+      ]
+    },
+    {
+      "name": "modifierGroups",
+      "documents": [
+        {
+          "id": "spice-level",
+          "data": {
+            "groupName": "Spice Level",
+            "selectionType": "SINGLE",
+            "options": [
+              {"optionName": "Mild", "priceChange": 0},
+              {"optionName": "Medium", "priceChange": 0},
+              {"optionName": "Hot", "priceChange": 0}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ingredients",
+      "documents": [
+        {
+          "id": "rice-noodle",
+          "data": {
+            "name": "Rice Noodles",
+            "unit": "kg",
+            "currentStock": 50,
+            "targetStock": 100,
+            "costPerUnit": 40
+          }
+        },
+        {
+          "id": "tea-leaves",
+          "data": {
+            "name": "Tea Leaves",
+            "unit": "kg",
+            "currentStock": 10,
+            "targetStock": 20,
+            "costPerUnit": 150
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,8 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "test": "vitest",
-    "test:emulator": "npm run build && firebase emulators:exec --project demo-test --only firestore,functions \"vitest run\""
+    "test:emulator": "npm run build && firebase emulators:exec --project demo-test --only firestore,functions \"vitest run\"",
+    "seed:emulator": "node scripts/seed-emulator.mjs"
   },
   "engines": {
     "node": "22"

--- a/functions/scripts/seed-emulator.mjs
+++ b/functions/scripts/seed-emulator.mjs
@@ -1,0 +1,55 @@
+import process from "node:process";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {readFile} from "node:fs/promises";
+import admin from "firebase-admin";
+
+const projectId = process.env.PROJECT_ID ?? "demo-test";
+const host = process.env.FIRESTORE_EMULATOR_HOST ?? "localhost:8080";
+process.env.GOOGLE_CLOUD_PROJECT = projectId;
+process.env.FIRESTORE_EMULATOR_HOST = host;
+
+if (!admin.apps.length) {
+  admin.initializeApp({projectId});
+}
+
+const firestore = admin.firestore();
+firestore.settings({ignoreUndefinedProperties: true});
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const seedPath = path.resolve(__dirname, "../fixtures/seed-data.json");
+
+function shouldReset() {
+  const flag = (process.env.RESET ?? "").toLowerCase();
+  return flag === "1" || flag === "true" || flag === "yes";
+}
+
+async function resetCollection(collectionName) {
+  if (!shouldReset()) {
+    return;
+  }
+  const ref = firestore.collection(collectionName);
+  await admin.firestore().recursiveDelete(ref);
+}
+
+async function seed() {
+  const raw = await readFile(seedPath, "utf8");
+  const seedFile = JSON.parse(raw);
+  for (const collection of seedFile.collections ?? []) {
+    const documents = collection.documents ?? [];
+    await resetCollection(collection.name);
+    for (const document of documents) {
+      const ref = firestore.collection(collection.name).doc(document.id);
+      await ref.set(document.data, {merge: false});
+    }
+    console.log(
+      `Seeded ${documents.length} docs to ${collection.name} on ${host}`
+    );
+  }
+  console.log("Seeding complete");
+}
+
+seed().catch((error) => {
+  console.error("Failed to seed emulator fixtures", error);
+  process.exitCode = 1;
+});

--- a/functions/src/build-metrics.ts
+++ b/functions/src/build-metrics.ts
@@ -1,0 +1,75 @@
+import {CallableRequest, onCall} from "firebase-functions/v2/https";
+import * as logger from "firebase-functions/logger";
+import {BigQuery} from "@google-cloud/bigquery";
+
+type FrameSummary = {
+  average: number;
+  p90: number;
+  p99: number;
+  max: number;
+};
+
+type MetricPayload = {
+  sessionId: string;
+  timestamp: string;
+  appVersion?: string | null;
+  buildMode: string;
+  platform: string;
+  frameCount: number;
+  build: FrameSummary;
+  raster: FrameSummary;
+  commit?: string;
+  branch?: string;
+  isWeb?: boolean;
+};
+
+const bigquery = new BigQuery();
+const datasetId = process.env.BUILD_METRICS_DATASET ?? "ops_metrics";
+const tableId = process.env.BUILD_METRICS_TABLE ?? "frame_performance";
+
+export const ingestBuildMetric = onCall(
+  {region: "asia-southeast1", memory: "128MiB", timeoutSeconds: 10},
+  async (request: CallableRequest<MetricPayload>) => {
+    const metric = request.data;
+    if (!metric) {
+      throw new Error("Missing metric payload");
+    }
+    if (!metric.sessionId || !metric.timestamp || !metric.build || !metric.raster) {
+      throw new Error("Metric payload missing required properties");
+    }
+
+    const row = {
+      session_id: metric.sessionId,
+      collected_at: metric.timestamp,
+      app_version: metric.appVersion ?? null,
+      build_mode: metric.buildMode,
+      platform: metric.platform,
+      frame_count: metric.frameCount,
+      build_average_ms: metric.build.average,
+      build_p90_ms: metric.build.p90,
+      build_p99_ms: metric.build.p99,
+      build_max_ms: metric.build.max,
+      raster_average_ms: metric.raster.average,
+      raster_p90_ms: metric.raster.p90,
+      raster_p99_ms: metric.raster.p99,
+      raster_max_ms: metric.raster.max,
+      commit: metric.commit ?? null,
+      branch: metric.branch ?? null,
+      is_web: metric.isWeb ?? false,
+      received_at: new Date().toISOString(),
+    };
+
+    try {
+      await bigquery.dataset(datasetId).table(tableId).insert([row], {
+        ignoreUnknownValues: true,
+        skipInvalidRows: true,
+      });
+      logger.info("Build metrics streamed", {sessionId: metric.sessionId});
+    } catch (error) {
+      logger.error("Failed to insert build metrics", error as Error, row);
+      throw error;
+    }
+
+    return {status: "ok"};
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,6 +29,7 @@ import {
   isBigQueryStreamingEnabled,
   streamAnalyticsRow,
 } from "./bigquery-streaming.js";
+export {ingestBuildMetric} from "./build-metrics.js";
 
 admin.initializeApp();
 const db = admin.firestore();

--- a/lib/edit_product_page.dart
+++ b/lib/edit_product_page.dart
@@ -11,6 +11,8 @@ import 'package:restaurant_models/restaurant_models.dart';
 
 import 'admin/modifier_management_page.dart';
 import 'barcode_scanner_page.dart';
+
+import 'services/firestore_converters.dart';
 class EditProductPage extends StatefulWidget {
   final Product? product;
 
@@ -204,14 +206,16 @@ class _EditProductPageState extends State<EditProductPage> {
             .where((station) => station.isNotEmpty)
             .toList(),
         prepTimeMinutes: double.tryParse(_prepTimeController.text) ?? 0.0,
-      ).toFirestore();
+      );
 
       try {
-        final collection = FirebaseFirestore.instance.collection('menu_items');
+        final collection = FirebaseFirestore.instance.menuItemsRef;
         if (widget.product == null) {
           await collection.add(productData);
         } else {
-          await collection.doc(widget.product!.id).update(productData);
+          await collection
+              .doc(widget.product!.id)
+              .set(productData, SetOptions(merge: true));
         }
         if (mounted) {
           context.pop();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/src/widgets/binding.dart' show DartPluginRegistrant;
@@ -76,6 +77,7 @@ import 'services/experiment_service.dart';
 import 'services/fx_rate_service.dart';
 import 'services/menu_cache_provider.dart';
 import 'services/ops_observability_service.dart';
+import 'services/performance_metrics_service.dart';
 import 'services/payment_gateway_service.dart';
 import 'services/print_spooler_service.dart';
 import 'services/printer_drawer_service.dart';
@@ -498,6 +500,18 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider.value(value: availability),
         ChangeNotifierProvider.value(value: observability),
+        Provider<PerformanceMetricsService>(
+          create: (_) {
+            final functions = FirebaseFunctions.instanceFor(
+              app: Firebase.app(),
+              region: 'asia-southeast1',
+            );
+            final service = PerformanceMetricsService(functions);
+            unawaited(service.start());
+            return service;
+          },
+          dispose: (_, service) => service.dispose(),
+        ),
         ChangeNotifierProvider(create: (ctx) => AppModeProvider()),
         ChangeNotifierProvider(create: (ctx) => AuthService()),
         Provider<ClientCacheService>(create: (_) => ClientCacheService()),

--- a/lib/product_management_page.dart
+++ b/lib/product_management_page.dart
@@ -3,6 +3,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:restaurant_models/restaurant_models.dart';
+
+import 'services/firestore_converters.dart';
 class ProductManagementPage extends StatelessWidget {
   const ProductManagementPage({super.key});
 
@@ -13,11 +15,9 @@ class ProductManagementPage extends StatelessWidget {
         title: const Text('Product Management'), // New title
         backgroundColor: Colors.indigo,
       ),
-      body: StreamBuilder<QuerySnapshot>(
-        // NOTE: We are still using the 'menu_items' collection for now.
-        // In a real project, you might migrate this to a 'products' collection.
+      body: StreamBuilder<QuerySnapshot<Product>>(
         stream: FirebaseFirestore.instance
-            .collection('menu_items')
+            .menuItemsRef
             .orderBy('name')
             .snapshots(),
         builder: (context, snapshot) {
@@ -30,9 +30,7 @@ class ProductManagementPage extends StatelessWidget {
 
           return ListView(
             children: snapshot.data!.docs.map((doc) {
-              final product = Product.fromFirestore(
-                doc,
-              ); // Create a Product object
+              final product = doc.data();
               return ListTile(
                 title: Text(product.name),
                 subtitle: Text('${product.price} Baht'),

--- a/lib/retail_pos_page.dart
+++ b/lib/retail_pos_page.dart
@@ -12,6 +12,7 @@ import 'package:restaurant_models/restaurant_models.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'cart_provider.dart';
+import 'services/firestore_converters.dart';
 import 'services/menu_cache_provider.dart';
 import 'widgets/customer_header_widget.dart';
 class RetailPosPage extends StatefulWidget {
@@ -61,12 +62,12 @@ class _RetailPosPageState extends State<RetailPosPage> {
 
       if (product == null) {
         final productQuery = await FirebaseFirestore.instance
-            .collection('menu_items')
+            .menuItemsRef
             .where('barcode', isEqualTo: code)
             .limit(1)
             .get();
         if (productQuery.docs.isNotEmpty) {
-          product = Product.fromFirestore(productQuery.docs.first);
+          product = productQuery.docs.first.data();
         }
       }
 

--- a/lib/services/firestore_converters.dart
+++ b/lib/services/firestore_converters.dart
@@ -1,0 +1,21 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:restaurant_models/restaurant_models.dart';
+
+/// Central place for Firestore typed collection helpers.
+extension AppFirestoreCollections on FirebaseFirestore {
+  /// Typed access to the `menu_items` collection.
+  CollectionReference<Product> get menuItemsRef => collection('menu_items')
+      .withConverter<Product>(
+        fromFirestore: (snapshot, _) =>
+            Product.fromMap(snapshot.data() ?? const <String, dynamic>{},
+                id: snapshot.id),
+        toFirestore: (product, _) => product.toFirestore(),
+      );
+
+  /// Typed access to active store documents.
+  CollectionReference<Store> get storesRef => collection('stores')
+      .withConverter<Store>(
+        fromFirestore: (snapshot, _) => Store.fromFirestore(snapshot),
+        toFirestore: (store, _) => store.toFirestore(),
+      );
+}

--- a/lib/services/menu_cache_provider.dart
+++ b/lib/services/menu_cache_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:restaurant_models/restaurant_models.dart';
 
 import 'client_cache_service.dart';
+import 'firestore_converters.dart';
 class MenuCacheProvider with ChangeNotifier {
   MenuCacheProvider(this._firestore, this._cacheService) {
     _initialize();
@@ -13,7 +14,7 @@ class MenuCacheProvider with ChangeNotifier {
   final FirebaseFirestore _firestore;
   final ClientCacheService _cacheService;
 
-  StreamSubscription<QuerySnapshot>? _subscription;
+  StreamSubscription<QuerySnapshot<Product>>? _subscription;
   List<Product> _menuItems = [];
   Map<String, Product> _productsById = {};
   Map<String, Product> _productsByBarcode = {};
@@ -61,12 +62,12 @@ class MenuCacheProvider with ChangeNotifier {
   void _subscribeToMenuItems() {
     _subscription?.cancel();
     _subscription = _firestore
-        .collection('menu_items')
+        .menuItemsRef
         .snapshots()
         .listen(
           (snapshot) {
             final items = snapshot.docs
-                .map((doc) => Product.fromFirestore(doc))
+                .map((doc) => doc.data())
                 .toList(growable: false);
             _applyMenuItems(items, fresh: true);
             unawaited(_cacheService.cacheMenuItems(items));

--- a/lib/services/performance_metrics_service.dart
+++ b/lib/services/performance_metrics_service.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Collects lightweight frame build/raster metrics and forwards summaries to
+/// BigQuery via a callable Cloud Function.
+class PerformanceMetricsService {
+  PerformanceMetricsService(this._functions)
+      : _sessionId =
+            '${DateTime.now().millisecondsSinceEpoch}-${Random().nextInt(1 << 32)}';
+
+  final FirebaseFunctions _functions;
+  final List<FrameTiming> _buffer = <FrameTiming>[];
+  final String _sessionId;
+  DateTime _lastFlush = DateTime.now();
+  late final TimingsCallback _callback = _handleTimings;
+  bool _listening = false;
+  bool _sending = false;
+  String? _appVersion;
+
+  /// Starts listening for frame timing updates.
+  Future<void> start() async {
+    if (_listening) {
+      return;
+    }
+    _listening = true;
+    try {
+      final info = await PackageInfo.fromPlatform();
+      _appVersion = '${info.version}+${info.buildNumber}';
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to resolve package info: $error');
+      }
+    }
+    SchedulerBinding.instance.addTimingsCallback(_callback);
+  }
+
+  void _handleTimings(List<FrameTiming> timings) {
+    _buffer.addAll(timings);
+    final now = DateTime.now();
+    final shouldFlush =
+        _buffer.length >= 120 || now.difference(_lastFlush).inSeconds >= 60;
+    if (shouldFlush) {
+      _lastFlush = now;
+      unawaited(_flush());
+    }
+  }
+
+  Future<void> _flush() async {
+    if (_sending || _buffer.isEmpty) {
+      return;
+    }
+    final frames = List<FrameTiming>.from(_buffer);
+    _buffer.clear();
+    _sending = true;
+
+    try {
+      final payload = _buildPayload(frames);
+      await _functions.httpsCallable('ingestBuildMetric').call(payload);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('PerformanceMetricsService failed to report metrics: $error');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      _sending = false;
+    }
+  }
+
+  Map<String, dynamic> _buildPayload(List<FrameTiming> frames) {
+    final buildDurationsMs = frames
+        .map((frame) => frame.buildDuration.inMicroseconds / 1000)
+        .toList(growable: false);
+    final rasterDurationsMs = frames
+        .map((frame) => frame.rasterDuration.inMicroseconds / 1000)
+        .toList(growable: false);
+
+    return <String, dynamic>{
+      'sessionId': _sessionId,
+      'timestamp': DateTime.now().toUtc().toIso8601String(),
+      'appVersion': _appVersion,
+      'buildMode': _buildModeLabel(),
+      'platform': _platformLabel(),
+      'frameCount': frames.length,
+      'build': _summarize(buildDurationsMs),
+      'raster': _summarize(rasterDurationsMs),
+      if (kIsWeb) 'isWeb': true,
+      'commit': const String.fromEnvironment('GIT_SHA', defaultValue: 'local'),
+      'branch': const String.fromEnvironment('GIT_BRANCH', defaultValue: ''),
+    };
+  }
+
+  Map<String, dynamic> _summarize(List<double> values) {
+    if (values.isEmpty) {
+      return <String, dynamic>{
+        'average': 0,
+        'p90': 0,
+        'p99': 0,
+        'max': 0,
+      };
+    }
+    final sorted = List<double>.from(values)..sort();
+    final sum = sorted.fold<double>(0, (total, value) => total + value);
+    return <String, dynamic>{
+      'average': sum / sorted.length,
+      'p90': _percentile(sorted, 0.9),
+      'p99': _percentile(sorted, 0.99),
+      'max': sorted.last,
+    };
+  }
+
+  double _percentile(List<double> sortedValues, double percentile) {
+    if (sortedValues.isEmpty) {
+      return 0;
+    }
+    final clamped = percentile.clamp(0, 1);
+    final position = clamped * (sortedValues.length - 1);
+    final lowerIndex = position.floor();
+    final upperIndex = position.ceil();
+    if (lowerIndex == upperIndex) {
+      return sortedValues[lowerIndex];
+    }
+    final lower = sortedValues[lowerIndex];
+    final upper = sortedValues[upperIndex];
+    final fraction = position - lowerIndex;
+    return lower + (upper - lower) * fraction;
+  }
+
+  String _buildModeLabel() {
+    if (kReleaseMode) {
+      return 'release';
+    }
+    if (kProfileMode) {
+      return 'profile';
+    }
+    return 'debug';
+  }
+
+  String _platformLabel() {
+    if (kIsWeb) {
+      return 'web';
+    }
+    return defaultTargetPlatform.name;
+  }
+
+  /// Stops listening for frame metrics.
+  void dispose() {
+    if (!_listening) {
+      return;
+    }
+    SchedulerBinding.instance.removeTimingsCallback(_callback);
+    _listening = false;
+  }
+}

--- a/lib/services/store_service.dart
+++ b/lib/services/store_service.dart
@@ -1,12 +1,15 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:restaurant_models/restaurant_models.dart';
+
+import 'firestore_converters.dart';
+
 class StoreService {
   StoreService(this._firestore);
 
   final FirebaseFirestore _firestore;
 
   Stream<List<Store>> watchStores({List<String>? storeIds}) {
-    Query<Map<String, dynamic>> query = _firestore.collection('stores');
+    Query<Store> query = _firestore.storesRef;
     if (storeIds != null && storeIds.isNotEmpty) {
       query = query.where(FieldPath.documentId, whereIn: storeIds);
     }
@@ -14,19 +17,17 @@ class StoreService {
 
     return query.snapshots().map(
       (snapshot) => snapshot.docs
-          .map((doc) => Store.fromFirestore(doc))
+          .map((doc) => doc.data())
           .toList(growable: false),
     );
   }
 
   Future<void> saveStore(Store store) async {
-    final collection = _firestore.collection('stores');
+    final collection = _firestore.storesRef;
     if (store.id.isEmpty) {
-      await collection.add(store.toFirestore());
+      await collection.add(store);
     } else {
-      await collection
-          .doc(store.id)
-          .set(store.toFirestore(), SetOptions(merge: true));
+      await collection.doc(store.id).set(store, SetOptions(merge: true));
     }
   }
 

--- a/tool/hooks/pre-commit.sh
+++ b/tool/hooks/pre-commit.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+mapfile -t CHANGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+mapfile -t DART_FILES < <(
+  printf '%s\n' "${CHANGED_FILES[@]}" | grep -E '\.dart$' || true
+)
+
+if [[ ${#DART_FILES[@]} -gt 0 ]]; then
+  echo "🛠  Formatting Dart files"
+  dart format "${DART_FILES[@]}"
+  git add "${DART_FILES[@]}"
+fi
+
+declare -A PACKAGE_DIRS=()
+for file in "${DART_FILES[@]}"; do
+  dir="$(dirname "$file")"
+  package_root=""
+  while [[ "$dir" != "." && "$dir" != "" ]]; do
+    if [[ -f "$dir/pubspec.yaml" ]]; then
+      package_root="$dir"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if [[ -z "$package_root" && -f "pubspec.yaml" ]]; then
+    package_root="."
+  fi
+  if [[ -n "$package_root" ]]; then
+    PACKAGE_DIRS["$package_root"]=1
+  fi
+done
+
+for pkg in "${!PACKAGE_DIRS[@]}"; do
+  echo "🔍 dart analyze ($pkg)"
+  (cd "$pkg" && dart analyze)
+done
+
+declare -A TEST_TARGETS=()
+for file in "${DART_FILES[@]}"; do
+  if [[ "$file" != *"_test.dart" ]]; then
+    continue
+  fi
+  dir="$(dirname "$file")"
+  package_root=""
+  while [[ "$dir" != "." && "$dir" != "" ]]; do
+    if [[ -f "$dir/pubspec.yaml" ]]; then
+      package_root="$dir"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if [[ -z "$package_root" && -f "pubspec.yaml" ]]; then
+    package_root="."
+  fi
+  if [[ -n "$package_root" ]]; then
+    relative="${file#$package_root/}"
+    TEST_TARGETS["$package_root"]+=" $relative"
+  fi
+done
+
+for pkg in "${!TEST_TARGETS[@]}"; do
+  targets="${TEST_TARGETS[$pkg]}"
+  if [[ -z "${targets// /}" ]]; then
+    continue
+  fi
+  echo "🧪 running tests ($pkg ->$targets)"
+  if grep -q "sdk: flutter" "$pkg/pubspec.yaml"; then
+    (cd "$pkg" && flutter test $targets)
+  else
+    (cd "$pkg" && dart test $targets)
+  fi
+done

--- a/tool/install_git_hooks.sh
+++ b/tool/install_git_hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$ROOT_DIR/.git/hooks"
+SCRIPT_DIR="$ROOT_DIR/tool/hooks"
+
+mkdir -p "$HOOKS_DIR"
+cp "$SCRIPT_DIR/pre-commit.sh" "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-commit"
+
+echo "Installed pre-commit hook -> $HOOKS_DIR/pre-commit"


### PR DESCRIPTION
## Summary
- add reusable fixtures and a one-command script to seed the Firestore emulator for QA
- introduce typed Firestore converters and migrate product/store flows to the strongly-typed APIs
- capture frame performance metrics in-app and stream summaries to BigQuery via a new callable function
- document the workflows and add Git hook helpers for formatting/analyze/test on staged Dart files

## Testing
- npm --prefix functions run lint *(fails: repository still uses legacy ESLint config format)*
- npm --prefix functions run build *(fails: existing TypeScript sources require ambient typings under the current toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68da7b0a762c8325b48f8213b8a65914