### PR TITLE
Fix overlay context for accessibility controls

### DIFF
--- a/lib/widgets/accessibility_overlay.dart
+++ b/lib/widgets/accessibility_overlay.dart
@@ -24,28 +24,38 @@ class _AccessibilityOverlayHostState extends State<AccessibilityOverlayHost> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        widget.child,
-        Align(
-          alignment: Alignment.bottomLeft,
-          child: SafeArea(
-            minimum: ResponsiveTokens.edgeInsetsSmall,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
+    return Overlay(
+      initialEntries: [
+        OverlayEntry(
+          builder: (context) {
+            return Stack(
               children: [
-                if (_panelVisible)
-                  _AccessibilityPanel(onClose: _togglePanel),
-                FloatingActionButton.small(
-                  heroTag: '_a11y_toggle',
-                  onPressed: _togglePanel,
-                  tooltip: 'Accessibility',
-                  child: Icon(_panelVisible ? Icons.visibility_off : Icons.visibility),
+                widget.child,
+                Align(
+                  alignment: Alignment.bottomLeft,
+                  child: SafeArea(
+                    minimum: ResponsiveTokens.edgeInsetsSmall,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (_panelVisible)
+                          _AccessibilityPanel(onClose: _togglePanel),
+                        FloatingActionButton.small(
+                          heroTag: '_a11y_toggle',
+                          onPressed: _togglePanel,
+                          tooltip: 'Accessibility',
+                          child: Icon(
+                            _panelVisible ? Icons.visibility_off : Icons.visibility,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ],
-            ),
-          ),
+            );
+          },
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- wrap the accessibility overlay host in an `Overlay` so tooltips have the required ancestor
- keep the accessibility controls rendered above the routed content without breaking overlay-dependent widgets

## Testing
- Not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68daae3a650883259acc481fb87a0be3