### PR TITLE
Add security extras support for permission evaluation

### DIFF
--- a/lib/security/permission_policy.dart
+++ b/lib/security/permission_policy.dart
@@ -8,11 +8,13 @@ class PermissionContext {
     required this.authService,
     required this.storeProvider,
     this.routerState,
+    this.extras,
   });
 
   final AuthService authService;
   final StoreProvider storeProvider;
   final GoRouterState? routerState;
+  final Object? extras;
 
   Store? get activeStore => storeProvider.activeStore;
   String? get activeStoreId => authService.activeStoreId;
@@ -21,6 +23,39 @@ class PermissionContext {
 
   bool hasPermission(Permission permission) =>
       authService.hasPermission(permission);
+
+  /// Attempts to cast the provided [extras] to the requested type.
+  T? extraAs<T>() {
+    final value = extras;
+    if (value is T) {
+      return value;
+    }
+    return null;
+  }
+
+  /// Convenience helper for working with [extras] represented as a map.
+  ///
+  /// Returns the value for [key] when it can be safely cast to [T]. When the
+  /// structure is not a map or the value cannot be cast the method returns
+  /// `null`.
+  T? extraValue<T>(String key) {
+    final value = extras;
+    if (value is Map<String, dynamic>) {
+      final candidate = value[key];
+      if (candidate is T) {
+        return candidate;
+      }
+      return null;
+    }
+    if (value is Map) {
+      final dynamic candidate = value[key];
+      if (candidate is T) {
+        return candidate;
+      }
+      return null;
+    }
+    return null;
+  }
 }
 
 typedef _PolicyEvaluator = bool Function(PermissionContext context);
@@ -76,14 +111,18 @@ class PermissionPolicy {
     );
   }
 
-  static PermissionPolicy storeAssignment() {
+  static PermissionPolicy storeAssignment({String? storeIdKey}) {
     return PermissionPolicy._((context) {
       final employee = context.authService.loggedInEmployee;
-      final activeStoreId = context.activeStoreId;
-      if (employee == null || activeStoreId == null) {
+      if (employee == null) {
         return false;
       }
-      return employee.storeIds.contains(activeStoreId);
+
+      final targetStoreId = _resolveStoreId(context, storeIdKey);
+      if (targetStoreId == null) {
+        return false;
+      }
+      return employee.storeIds.contains(targetStoreId);
     });
   }
 
@@ -109,4 +148,48 @@ class PermissionPolicy {
 
   PermissionPolicy negate() =>
       PermissionPolicy._((context) => !evaluate(context));
+
+  static String? _resolveStoreId(
+    PermissionContext context,
+    String? storeIdKey,
+  ) {
+    final extra = context.extras;
+    if (extra is Store) {
+      return extra.id.isEmpty ? null : extra.id;
+    }
+    if (extra is String && extra.isNotEmpty) {
+      return extra;
+    }
+    if (extra is Map) {
+      if (storeIdKey != null) {
+        final dynamic keyed = extra[storeIdKey];
+        if (keyed is String && keyed.isNotEmpty) {
+          return keyed;
+        }
+      }
+      final dynamic explicit = extra['storeId'] ?? extra['id'];
+      if (explicit is String && explicit.isNotEmpty) {
+        return explicit;
+      }
+    }
+
+    if (storeIdKey != null) {
+      final fromExtras = context.extraValue<String>(storeIdKey);
+      if (fromExtras != null && fromExtras.isNotEmpty) {
+        return fromExtras;
+      }
+    }
+
+    final routeStoreId =
+        context.routerState?.pathParameters[storeIdKey ?? 'storeId'];
+    if (routeStoreId != null && routeStoreId.isNotEmpty) {
+      return routeStoreId;
+    }
+
+    final activeStoreId = context.activeStoreId;
+    if (activeStoreId != null && activeStoreId.isNotEmpty) {
+      return activeStoreId;
+    }
+    return null;
+  }
 }

--- a/lib/widgets/permission_gate.dart
+++ b/lib/widgets/permission_gate.dart
@@ -10,11 +10,13 @@ class PermissionGate extends StatelessWidget {
     required this.policy,
     required this.builder,
     this.fallback,
+    this.extra,
   });
 
   final PermissionPolicy policy;
   final WidgetBuilder builder;
   final WidgetBuilder? fallback;
+  final Object? extra;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +25,7 @@ class PermissionGate extends StatelessWidget {
         final permissionContext = PermissionContext(
           authService: authService,
           storeProvider: storeProvider,
+          extras: extra,
         );
         if (policy.evaluate(permissionContext)) {
           return builder(context);

--- a/lib/widgets/route_permission_guard.dart
+++ b/lib/widgets/route_permission_guard.dart
@@ -58,6 +58,7 @@ class _RoutePermissionGuardState extends State<RoutePermissionGuard> {
           authService: authService,
           storeProvider: storeProvider,
           routerState: widget.state,
+          extras: widget.state.extra,
         );
 
         if (!authService.isLoggedIn) {


### PR DESCRIPTION
## Summary
- extend the security permission context to carry optional extras and helpers
- allow the route guard and widget gate to forward extras into permission checks
- enhance the store assignment policy to resolve store ids from extras, routes, or active store

## Testing
- not run (flutter sdk unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbca4959f48325b2102d1fcbe333bf