### PR TITLE
Fix QA playbook list const initialization error

### DIFF
--- a/lib/admin/qa_playbooks_page.dart
+++ b/lib/admin/qa_playbooks_page.dart
@@ -466,7 +466,7 @@ class QaPlaybook {
   }
 }
 
-const List<QaPlaybook> _playbooks = [
+final List<QaPlaybook> _playbooks = [
   QaPlaybook(
     title: 'Payments: Card Reader Offline',
     summary: 'Investigate when the payment terminal cannot reach the gateway.',


### PR DESCRIPTION
## Summary
- update the QA playbooks collection to be a runtime list so non-const values are allowed

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd329f74483258c9d707fa659d365