### PR TITLE
Add automatic tag generation for QA playbooks

### DIFF
--- a/test/admin/qa_playbooks_page_test.dart
+++ b/test/admin/qa_playbooks_page_test.dart
@@ -3,6 +3,34 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:restaurant_app_final/admin/qa_playbooks_page.dart';
 
 void main() {
+  test('QaPlaybook generates tags from playbook content', () {
+    final playbook = QaPlaybook(
+      title: 'Payments Terminal Offline',
+      owner: 'Ops Guild',
+      tags: const ['priority'],
+      revisions: const [
+        PlaybookRevision(
+          id: 'v1',
+          summary: 'Terminal outage scenario',
+          triggers: [
+            'Cashiers report repeated payment failures with status OFFLINE.',
+          ],
+          steps: [
+            'Power-cycle the card reader and verify it reconnects to Wi-Fi.',
+          ],
+          followUp: [
+            'Escalate to network engineering if the reader does not recover.',
+          ],
+        ),
+      ],
+    );
+
+    expect(
+      playbook.allTags,
+      containsAll(<String>['critical', 'hardware', 'payments', 'priority']),
+    );
+  });
+
   testWidgets('Selecting older revision updates checklist and metadata',
       (tester) async {
     await tester.pumpWidget(const MaterialApp(home: QaPlaybooksPage()));
@@ -33,5 +61,25 @@ void main() {
       find.textContaining('Original draft with emphasis on vendor support confirmation.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('Tag filtering works with automatically generated tags',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: QaPlaybooksPage()));
+    await tester.pumpAndSettle();
+
+    final paymentsChip = find.widgetWithText(FilterChip, 'payments');
+    expect(paymentsChip, findsOneWidget);
+
+    await tester.tap(paymentsChip);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Payments: Card Reader Offline'), findsOneWidget);
+    expect(find.text('Kitchen Display Queue Stalling'), findsNothing);
+
+    await tester.tap(paymentsChip);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Kitchen Display Queue Stalling'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add a keyword-driven helper to build standardized QA playbook tags and merge them with manual overrides
- surface the combined tag list through the QaPlaybook model and use it in the sidebar filter and detail chips
- expand test coverage to validate tag generation and filtering behaviour

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dccaa94f9083259453d3ee97d6ec79