### PR TITLE
Use FakeFirebaseFirestore in customer checkout test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,6 +84,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
+  fake_cloud_firestore: ^2.4.0
   flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the

--- a/test/customer_checkout_page_test.dart
+++ b/test/customer_checkout_page_test.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
@@ -10,33 +10,6 @@ import 'package:restaurant_app_final/services/sync_queue_service.dart';
 import 'package:restaurant_models/restaurant_models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/fake.dart';
-
-class _FakeFirebaseFirestore extends Fake implements FirebaseFirestore {
-  final _FakeCollectionReference _collection = _FakeCollectionReference();
-
-  @override
-  CollectionReference<Map<String, dynamic>> collection(String path) {
-    return _collection..path = path;
-  }
-}
-
-class _FakeCollectionReference extends Fake
-    implements CollectionReference<Map<String, dynamic>> {
-  String? path;
-
-  @override
-  Future<DocumentReference<Map<String, dynamic>>> add(
-    Map<String, dynamic> data,
-  ) async {
-    return _FakeDocumentReference();
-  }
-}
-
-class _FakeDocumentReference extends Fake
-    implements DocumentReference<Map<String, dynamic>> {
-  @override
-  String get id => 'fake-id';
-}
 
 class _FakeConnectivity extends Fake implements Connectivity {
   final _controller = StreamController<List<ConnectivityResult>>.broadcast();
@@ -63,8 +36,9 @@ void main() {
     SharedPreferences.setMockInitialValues({});
 
     final connectivity = _FakeConnectivity();
+    final firestore = FakeFirebaseFirestore();
     final syncQueue = SyncQueueService(
-      _FakeFirebaseFirestore(),
+      firestore,
       connectivity: connectivity,
     );
     final defaultOnError = FlutterError.onError;


### PR DESCRIPTION
## Summary
- add fake_cloud_firestore as a dev dependency
- replace bespoke Firestore fakes in the customer checkout widget test with FakeFirebaseFirestore

## Testing
- flutter test test/customer_checkout_page_test.dart *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9477c2d083259e721d0d9c331e64