### PR TITLE
Import cart provider in checkout test

### DIFF
--- a/test/customer_checkout_page_test.dart
+++ b/test/customer_checkout_page_test.dart
@@ -5,6 +5,7 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:restaurant_app_final/cart_provider.dart';
 import 'package:restaurant_app_final/customer_checkout_page.dart';
 import 'package:restaurant_app_final/services/sync_queue_service.dart';
 import 'package:restaurant_models/restaurant_models.dart';


### PR DESCRIPTION
## Summary
- add the cart provider import to the checkout widget test so the CartItem reference resolves

## Testing
- dart analyze *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9583ff508325927f828c1a7e2071