### PR TITLE
chore: bump fake_cloud_firestore to 3.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  fake_cloud_firestore: ^2.4.0
+  fake_cloud_firestore: ^3.1.0
   flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
## Summary
- update the fake_cloud_firestore dev dependency to the latest compatible release to resolve the rxdart constraint conflict

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de988b6d048325b0ca3993641749f2