### PR TITLE
Reduce redundant cart notifications when clearing

### DIFF
--- a/lib/cart_provider.dart
+++ b/lib/cart_provider.dart
@@ -421,9 +421,13 @@ class CartProvider with ChangeNotifier {
     if (_appliedGiftCard == null && _giftCardAmount == 0) {
       return;
     }
+    _resetGiftCard();
+    notifyListeners();
+  }
+
+  void _resetGiftCard() {
     _appliedGiftCard = null;
     _giftCardAmount = 0.0;
-    notifyListeners();
   }
 
   void applyStoreCredit(double amount, {double? availableBalance}) {
@@ -442,8 +446,12 @@ class CartProvider with ChangeNotifier {
 
   void removeStoreCredit() {
     if (_storeCreditAmount == 0) return;
-    _storeCreditAmount = 0.0;
+    _resetStoreCredit();
     notifyListeners();
+  }
+
+  void _resetStoreCredit() {
+    _storeCreditAmount = 0.0;
   }
 
   void overrideCustomerStoreCredit(double newBalance) {
@@ -567,10 +575,14 @@ class CartProvider with ChangeNotifier {
   }
 
   void removeDiscount() {
+    _resetDiscount();
+    notifyListeners();
+  }
+
+  void _resetDiscount() {
     _discount = 0.0;
     _discountType = 'none';
     _appliedPromotion = null;
-    notifyListeners();
   }
 
   void setServiceChargeEnabled(bool value) {
@@ -625,9 +637,9 @@ class CartProvider with ChangeNotifier {
     _selectedHouseAccount = null;
     _invoiceToHouseAccount = false;
     _customHouseAccountDueDate = null;
-    removeDiscount();
-    removeGiftCard();
-    removeStoreCredit();
+    _resetDiscount();
+    _resetGiftCard();
+    _resetStoreCredit();
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- reset discounts, gift cards, and store credit without emitting extra notifications during cart clearing
- reuse new internal reset helpers so individual removal methods still update listeners once
- prevent redundant listener updates that were freezing the UI after picking a table

## Testing
- not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68de9adf7a50832584cb28d5d117b9dc