### PR TITLE
Add GitHub Actions release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Build Flutter web app
+        run: flutter build web --release
+
+      - name: Build Android release APK
+        run: flutter build apk --release
+
+      - name: Archive web build
+        run: tar -czf web-build.tar.gz -C build web
+
+      - name: Prepare APK artifact
+        run: cp build/app/outputs/flutter-apk/app-release.apk restaurant-pos-release.apk
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            web-build.tar.gz
+            restaurant-pos-release.apk
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload web build asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/web-build.tar.gz
+          asset_name: web-build.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Android APK asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/restaurant-pos-release.apk
+          asset_name: restaurant-pos-release.apk
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
## Summary
- add a release workflow that builds Flutter web and Android artifacts for tagged releases or manual triggers
- package the generated builds as artifacts and publish them as GitHub release assets

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68df1e53e250832587768e9913b8e783