### PR TITLE
Add deployment preflight script and release channel helpers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -37,6 +37,7 @@
         "*.local"
       ],
       "predeploy": [
+        "./tool/preflight_deploy.sh",
         "npm --prefix \"$RESOURCE_DIR\" run build"
       ]
     }

--- a/lib/feature_flags/feature_flag_provider.dart
+++ b/lib/feature_flags/feature_flag_provider.dart
@@ -163,6 +163,27 @@ class FeatureFlagProvider with ChangeNotifier {
     );
   }
 
+  Future<void> configureReleaseChannel({
+    required String channel,
+    ReleaseEnvironment? environment,
+    Map<String, bool>? flagOverrides,
+    Map<String, StagedRollout>? rollouts,
+    bool clear = false,
+  }) async {
+    final tenantId = _tenantId;
+    if (tenantId == null) {
+      throw StateError('Cannot modify feature flags without a tenant context.');
+    }
+    await _featureFlagService.configureReleaseChannel(
+      tenantId: tenantId,
+      channel: channel,
+      environment: environment,
+      flagOverrides: flagOverrides,
+      rollouts: rollouts,
+      clear: clear,
+    );
+  }
+
   @override
   void dispose() {
     _subscription?.cancel();

--- a/tool/preflight_deploy.sh
+++ b/tool/preflight_deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+info() {
+  echo -e "\033[1;34m==>\033[0m $*"
+}
+
+warn() {
+  echo -e "\033[1;33m==>\033[0m $*"
+}
+
+info "Running deployment preflight checks"
+
+# Flutter specific checks
+if command -v flutter >/dev/null 2>&1; then
+  info "\nChecking Flutter format/analyze/test"
+  (cd "$ROOT_DIR" && flutter format --set-exit-if-changed lib test)
+  (cd "$ROOT_DIR" && flutter analyze)
+  (cd "$ROOT_DIR" && flutter test)
+else
+  warn "Flutter not available - skipping Flutter formatting/analyze/test"
+fi
+
+# Melos workspace sanity
+if command -v melos >/dev/null 2>&1; then
+  info "\nValidating Melos workspace"
+  (cd "$ROOT_DIR" && melos bootstrap)
+  (cd "$ROOT_DIR" && melos run analyze)
+  (cd "$ROOT_DIR" && melos run test)
+else
+  warn "Melos not installed - skipping workspace checks"
+fi
+
+# Cloud Functions lint + tests
+if command -v npm >/dev/null 2>&1; then
+  info "\nRunning Cloud Functions lint"
+  if [ ! -d "$ROOT_DIR/functions/node_modules" ]; then
+    (cd "$ROOT_DIR/functions" && npm install)
+  fi
+  (cd "$ROOT_DIR/functions" && npm run lint)
+  info "\nExecuting Cloud Functions tests"
+  (cd "$ROOT_DIR/functions" && npm test)
+else
+  warn "npm not available - skipping Cloud Functions lint/test"
+fi
+
+info "\nAll preflight checks passed"


### PR DESCRIPTION
## Summary
- add a reusable deployment preflight script and wire it into the Firebase predeploy hook
- document the deployment workflow and the feature-flag based canary/rollback process
- extend the feature flag service/provider to manage release channel overrides programmatically

## Testing
- ./tool/preflight_deploy.sh *(fails: npm install blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1fcdea408325a1f50d622dc6ac9b