### PR TITLE
Add smoke integration test and synthetic monitor

### DIFF
--- a/functions/tests/syntheticMonitor.test.ts
+++ b/functions/tests/syntheticMonitor.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from "vitest";
+import {
+  parseExpectedStatusCodes,
+  parseSyntheticTimeout,
+} from "../src/index.js";
+
+describe("parseSyntheticTimeout", () => {
+  it("returns fallback for invalid values", () => {
+    expect(parseSyntheticTimeout(undefined, 3000)).toBe(3000);
+    expect(parseSyntheticTimeout("", 2000)).toBe(2000);
+    expect(parseSyntheticTimeout("abc", 1500)).toBe(1500);
+    expect(parseSyntheticTimeout("-5", 1200)).toBe(1200);
+  });
+
+  it("clamps to the maximum allowed timeout", () => {
+    expect(parseSyntheticTimeout("120000", 5000)).toBe(60000);
+  });
+
+  it("parses valid integers", () => {
+    expect(parseSyntheticTimeout("4500", 5000)).toBe(4500);
+  });
+});
+
+describe("parseExpectedStatusCodes", () => {
+  it("returns null when the input is empty or invalid", () => {
+    expect(parseExpectedStatusCodes()).toBeNull();
+    expect(parseExpectedStatusCodes(" ")).toBeNull();
+    expect(parseExpectedStatusCodes("foo,bar")).toBeNull();
+  });
+
+  it("extracts numeric status codes", () => {
+    const result = parseExpectedStatusCodes("200, 204,500");
+    expect(result).not.toBeNull();
+    expect(Array.from(result!)).toEqual([200, 204, 500]);
+  });
+
+  it("ignores numbers outside the HTTP range", () => {
+    const result = parseExpectedStatusCodes("99,600,200");
+    expect(result).not.toBeNull();
+    expect(Array.from(result!)).toEqual([200]);
+  });
+});

--- a/integration_test/post_release_smoke_test.dart
+++ b/integration_test/post_release_smoke_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:restaurant_app_final/main_prod.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('post-release smoke test navigates to login', (tester) async {
+    await app.main();
+
+    // Allow the first frame and the splash timer to complete.
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Please enter your 4-digit PIN'), findsOneWidget);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## Summary
- add a post-release smoke integration test that boots the production entrypoint and waits for the PIN login screen
- register the integration_test SDK dependency required for the new smoke test
- add a scheduled synthetic monitor Cloud Function with helper utilities and unit coverage for the configuration parsers

## Testing
- npm --prefix functions run lint *(fails: ESLint 9.34.0 requires eslint.config.js and the repo still uses the legacy configuration format)*
- npm --prefix functions test *(fails: local vitest binary missing because npm install cannot run in this environment due to 403 responses from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df22b775e48325bd3b20ea1073c4ca