### PR TITLE
Add BigQuery mock for synthetic monitor tests

### DIFF
--- a/functions/tests/__mocks__/@google-cloud/bigquery.ts
+++ b/functions/tests/__mocks__/@google-cloud/bigquery.ts
@@ -1,0 +1,11 @@
+export class BigQuery {
+  dataset() {
+    return {
+      table: () => ({
+        insert: async () => Promise.resolve(),
+      }),
+    };
+  }
+}
+
+export default BigQuery;

--- a/functions/tests/syntheticMonitor.test.ts
+++ b/functions/tests/syntheticMonitor.test.ts
@@ -1,4 +1,5 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
+vi.mock("@google-cloud/bigquery");
 import {
   parseExpectedStatusCodes,
   parseSyntheticTimeout,


### PR DESCRIPTION
## Summary
- add a lightweight manual mock for `@google-cloud/bigquery` used by synthetic monitor tests
- register the mock before loading the synthetic monitor helpers so Vitest can resolve the dependency

## Testing
- npm --prefix functions test *(fails: `vitest` binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df2a9b7b70832592db141fe64302bb