### PR TITLE
Fix theme extension spread typing

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -92,7 +92,7 @@ class AppTheme {
         ),
       ),
       extensions: <ThemeExtension<dynamic>>[
-        ...base.extensions.values,
+        ...base.extensions.values.cast<ThemeExtension<dynamic>>(),
         colorTokens,
         spacingTokens,
         radiusTokens,


### PR DESCRIPTION
## Summary
- cast ThemeData base extensions to dynamic ThemeExtension instances before merging

## Testing
- not run (tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfcbcdd60883259f804ee706c26882