### PR TITLE
Fix ThemeData extensions typing

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -91,8 +91,8 @@ class AppTheme {
           vertical: spacingTokens.xs,
         ),
       ),
-      extensions: <ThemeExtension<dynamic>>[
-        ...base.extensions.values.cast<ThemeExtension<dynamic>>(),
+      extensions: [
+        ...base.extensions.values,
         colorTokens,
         spacingTokens,
         radiusTokens,


### PR DESCRIPTION
## Summary
- adjust the AppTheme extensions list to spread existing values without an invalid cast

## Testing
- Not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dfcd499c5083258d4d6a6e9740340e