### PR TITLE
Fix overflow handling in backoffice schema form card

### DIFF
--- a/lib/admin/backoffice_schema_page.dart
+++ b/lib/admin/backoffice_schema_page.dart
@@ -132,12 +132,9 @@ class _BackofficeSchemaPageState extends State<BackofficeSchemaPage> {
   }
 
   Widget _buildFormPane(ThemeData theme) {
-    return Card(
-      elevation: 4,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final formContent = Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             LayoutBuilder(
@@ -214,8 +211,26 @@ class _BackofficeSchemaPageState extends State<BackofficeSchemaPage> {
               ),
             ),
           ],
-        ),
-      ),
+        );
+
+        final bool hasBoundedHeight = constraints.maxHeight.isFinite;
+        final EdgeInsets padding = const EdgeInsets.all(24);
+
+        return Card(
+          elevation: 4,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          child: hasBoundedHeight
+              ? SingleChildScrollView(
+                  padding: padding,
+                  child: formContent,
+                )
+              : Padding(
+                  padding: padding,
+                  child: formContent,
+                ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- wrap the backoffice form card in a LayoutBuilder so the content can adapt to its constraints
- switch to a scrollable container when the form is height-constrained to prevent RenderFlex overflows

## Testing
- flutter test *(fails: Flutter SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd3d9dbe083259c9116f11700de8a