### PR TITLE
Add responsive admin navigation scaffold

### DIFF
--- a/lib/admin/admin_page.dart
+++ b/lib/admin/admin_page.dart
@@ -10,290 +10,438 @@ import '../app_mode_provider.dart';
 import '../qr_generator_page.dart';
 import '../stock_provider.dart';
 import '../theme_provider.dart';
-class AdminPage extends StatelessWidget {
+import '../widgets/responsive_scaffold.dart';
+
+class AdminPage extends StatefulWidget {
   const AdminPage({super.key});
 
   @override
+  State<AdminPage> createState() => _AdminPageState();
+}
+
+class _AdminPageState extends State<AdminPage> {
+  int _selectedCategoryIndex = 0;
+
+  static final List<_AdminMenuItem> _allMenuItems = [
+    _AdminMenuItem(
+      title: 'Low Stock Alerts',
+      subtitle: 'View items that need reordering',
+      icon: Icons.warning_amber_rounded,
+      route: '/admin/low-stock-alerts',
+      isSpecial: true,
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+      showLowStockBadge: true,
+    ),
+    _AdminMenuItem(
+      title: 'Table Reservations',
+      subtitle: 'Manage customer bookings',
+      icon: Icons.calendar_month_outlined,
+      route: '/admin/reservations',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant],
+    ),
+    _AdminMenuItem(
+      title: 'Employee Management',
+      subtitle: 'Manage staff, roles, and PINs',
+      icon: Icons.people_alt_outlined,
+      route: '/admin/employees',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Time Clock Report',
+      subtitle: 'View staff work hours',
+      icon: Icons.access_time_filled,
+      route: '/admin/time-report',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Promotion Management',
+      subtitle: 'Create and manage discount codes',
+      icon: Icons.local_offer_outlined,
+      route: '/admin/promotions',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Backoffice Designer',
+      subtitle: 'Build schema-driven workflows and forms',
+      icon: Icons.auto_awesome_mosaic_outlined,
+      route: '/admin/schema-designer',
+      category: _AdminCategory.tools,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Punch Cards',
+      subtitle: 'Manage loyalty punch cards',
+      icon: Icons.card_giftcard,
+      route: '/admin/punch-cards',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'QA Playbooks',
+      subtitle: 'Runbooks for on-call and QA sign-off',
+      icon: Icons.fact_check_outlined,
+      route: '/admin/qa-playbooks',
+      category: _AdminCategory.tools,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Ops Observability',
+      subtitle: 'Inspect logs & platform health signals',
+      icon: Icons.monitor_heart_outlined,
+      route: '/admin/observability',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Manage Modifiers',
+      subtitle: 'Manage product options and combos',
+      icon: Icons.add_link,
+      route: '/admin/modifiers',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant],
+    ),
+    _AdminMenuItem(
+      title: 'Manage Products',
+      subtitle: 'Add, edit, or delete items',
+      icon: Icons.style_outlined,
+      route: '/admin/products',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Supplier Management',
+      subtitle: 'Manage suppliers and contacts',
+      icon: Icons.groups_outlined,
+      route: '/admin/suppliers',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Purchase Orders',
+      subtitle: 'Order stock from suppliers',
+      icon: Icons.receipt_long_outlined,
+      route: '/admin/purchase-orders',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Stocktake & Adjustments',
+      subtitle: 'Scan inventory and record counts',
+      icon: Icons.qr_code_2_outlined,
+      route: '/admin/stocktake',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Manage Inventory',
+      subtitle: 'Manage ingredients and stock levels',
+      icon: Icons.inventory_2_outlined,
+      route: '/admin/inventory',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Waste Tracking',
+      subtitle: 'Record expired or damaged stock',
+      icon: Icons.delete_sweep_outlined,
+      route: '/admin/waste',
+      category: _AdminCategory.inventory,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Sales Dashboard',
+      subtitle: 'View sales and reports',
+      icon: Icons.dashboard_outlined,
+      route: '/admin/dashboard',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Analytics & CRM',
+      subtitle: 'BigQuery export and RFM scoring',
+      icon: Icons.analytics_outlined,
+      route: '/admin/analytics',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'End of Day Report',
+      subtitle: 'Close out and view final numbers',
+      icon: Icons.assessment_outlined,
+      route: '/admin/eod',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Accounting Export',
+      subtitle: 'Export data to CSV files',
+      icon: Icons.upload_file_outlined,
+      route: '/admin/accounting-export',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Branch Management',
+      subtitle: 'Manage stores and staff permissions',
+      icon: Icons.store_mall_directory_outlined,
+      route: '/admin/stores',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Kitchen Display System',
+      subtitle: 'View active kitchen orders',
+      icon: Icons.kitchen_outlined,
+      route: '/admin/kds',
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant],
+    ),
+    _AdminMenuItem(
+      title: 'Audit Trail',
+      subtitle: 'Review inventory & staff activity',
+      icon: Icons.policy_outlined,
+      route: '/admin/audit-log',
+      category: _AdminCategory.insights,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Record Expense',
+      subtitle: 'Log other business costs',
+      icon: Icons.payment_outlined,
+      pageBuilder: (_) => const AddExpensePage(),
+      category: _AdminCategory.operations,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+    _AdminMenuItem(
+      title: 'Generate QR Code',
+      subtitle: 'For customer self-ordering',
+      icon: Icons.qr_code_scanner_outlined,
+      pageBuilder: (_) => const QrGeneratorPage(),
+      category: _AdminCategory.tools,
+      modes: const [AppMode.restaurant],
+    ),
+    _AdminMenuItem(
+      title: 'Dark Mode',
+      subtitle: 'Toggle UI theme',
+      icon: Icons.brightness_6_outlined,
+      isThemeToggle: true,
+      category: _AdminCategory.tools,
+      modes: const [AppMode.restaurant, AppMode.retail],
+    ),
+  ];
+
+  @override
   Widget build(BuildContext context) {
-    final stockProvider = Provider.of<StockProvider>(context);
-    final appModeProvider = Provider.of<AppModeProvider>(context);
+    final lowStockCount = context.watch<StockProvider>().lowStockIngredients.length;
+    final currentMode = context.watch<AppModeProvider>().appMode;
+    final selectedCategory = _AdminCategory.values[_selectedCategoryIndex];
 
-    final lowStockCount = stockProvider.lowStockIngredients.length;
-    final currentMode = appModeProvider.appMode;
+    final menuItems = _allMenuItems
+        .where(
+          (item) =>
+              item.category == selectedCategory &&
+              item.modes.contains(currentMode),
+        )
+        .toList();
 
-    // --- Responsive Logic ---
-    final screenWidth = MediaQuery.of(context).size.width;
-    final int crossAxisCount;
-    final double childAspectRatio;
-
-    if (screenWidth < 600) {
-      // Mobile layout
-      crossAxisCount = 2;
-      childAspectRatio = 1.0;
-    } else if (screenWidth < 1200) {
-      // Tablet layout
-      crossAxisCount = 3;
-      childAspectRatio = 1.1;
-    } else {
-      // Desktop layout
-      crossAxisCount = 4;
-      childAspectRatio = 1.0;
-    }
-    // --------------------
-
-    final List<Map<String, dynamic>> allAdminMenuItems = [
-      {
-        'title': 'Low Stock Alerts',
-        'subtitle': 'View items that need reordering',
-        'icon': Icons.warning_amber_rounded,
-        'route': '/admin/low-stock-alerts',
-        'isSpecial': true,
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Table Reservations',
-        'subtitle': 'Manage customer bookings',
-        'icon': Icons.calendar_month_outlined,
-        'route': '/admin/reservations',
-        'modes': [AppMode.restaurant],
-      },
-      {
-        'title': 'Employee Management',
-        'subtitle': 'Manage staff, roles, and PINs',
-        'icon': Icons.people_alt_outlined,
-        'route': '/admin/employees',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Time Clock Report',
-        'subtitle': 'View staff work hours',
-        'icon': Icons.access_time_filled,
-        'route': '/admin/time-report',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Promotion Management',
-        'subtitle': 'Create and manage discount codes',
-        'icon': Icons.local_offer_outlined,
-        'route': '/admin/promotions',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Backoffice Designer',
-        'subtitle': 'Build schema-driven workflows and forms',
-        'icon': Icons.auto_awesome_mosaic_outlined,
-        'route': '/admin/schema-designer',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Punch Cards',
-        'subtitle': 'Manage loyalty punch cards',
-        'icon': Icons.card_giftcard,
-        'route': '/admin/punch-cards',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'QA Playbooks',
-        'subtitle': 'Runbooks for on-call and QA sign-off',
-        'icon': Icons.fact_check_outlined,
-        'route': '/admin/qa-playbooks',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Ops Observability',
-        'subtitle': 'Inspect logs & platform health signals',
-        'icon': Icons.monitor_heart_outlined,
-        'route': '/admin/observability',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      // --- ADDED THIS NEW MENU ITEM ---
-      {
-        'title': 'Manage Modifiers',
-        'subtitle': 'Manage product options and combos',
-        'icon': Icons.add_link,
-        'route': '/admin/modifiers',
-        'modes': [AppMode.restaurant],
-      },
-      // ---------------------------------
-      {
-        'title': 'Manage Products',
-        'subtitle': 'Add, edit, or delete items',
-        'icon': Icons.style_outlined,
-        'route': '/admin/products',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Supplier Management',
-        'subtitle': 'Manage suppliers and contacts',
-        'icon': Icons.groups_outlined,
-        'route': '/admin/suppliers',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Purchase Orders',
-        'subtitle': 'Order stock from suppliers',
-        'icon': Icons.receipt_long_outlined,
-        'route': '/admin/purchase-orders',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Manage Inventory',
-        'subtitle': 'Manage ingredients and stock levels',
-        'icon': Icons.inventory_2_outlined,
-        'route': '/admin/inventory',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Waste Tracking',
-        'subtitle': 'Record expired or damaged stock',
-        'icon': Icons.delete_sweep_outlined,
-        'route': '/admin/waste',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Sales Dashboard',
-        'subtitle': 'View sales and reports',
-        'icon': Icons.dashboard_outlined,
-        'route': '/admin/dashboard',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Analytics & CRM',
-        'subtitle': 'BigQuery export and RFM scoring',
-        'icon': Icons.analytics_outlined,
-        'route': '/admin/analytics',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'End of Day Report',
-        'subtitle': 'Close out and view final numbers',
-        'icon': Icons.assessment_outlined,
-        'route': '/admin/eod',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Accounting Export',
-        'subtitle': 'Export data to CSV files',
-        'icon': Icons.upload_file_outlined,
-        'route': '/admin/accounting-export',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Kitchen Display System',
-        'subtitle': 'View active kitchen orders',
-        'icon': Icons.kitchen_outlined,
-        'route': '/admin/kds',
-        'modes': [AppMode.restaurant],
-      },
-      {
-        'title': 'Record Expense',
-        'subtitle': 'Log other business costs',
-        'icon': Icons.payment_outlined,
-        'route': 'add_expense_page',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-      {
-        'title': 'Generate QR Code',
-        'subtitle': 'For customer self-ordering',
-        'icon': Icons.qr_code_scanner_outlined,
-        'route': 'qr_generator_page',
-        'modes': [AppMode.restaurant],
-      },
-      {
-        'title': 'Dark Mode',
-        'subtitle': 'Toggle UI theme',
-        'icon': Icons.brightness_6_outlined,
-        'route': 'toggle_dark_mode',
-        'modes': [AppMode.restaurant, AppMode.retail],
-      },
-    ];
-
-    final filteredMenuItems = allAdminMenuItems.where((item) {
-      final modes = item['modes'] as List<AppMode>;
-      return modes.contains(currentMode);
-    }).toList();
-
-    return Scaffold(
+    return ResponsiveScaffold(
       appBar: AppBar(
         title: const Text('Admin Panel'),
         backgroundColor: Colors.indigo,
       ),
-      body: GridView.builder(
-        padding: const EdgeInsets.all(16.0),
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: crossAxisCount,
-          crossAxisSpacing: 16,
-          mainAxisSpacing: 16,
-          childAspectRatio: childAspectRatio,
-        ),
-        itemCount: filteredMenuItems.length,
-        itemBuilder: (context, index) {
-          final item = filteredMenuItems[index];
+      destinations: _AdminCategory.values
+          .map(
+            (category) => NavigationDestination(
+              icon: Icon(category.icon),
+              label: category.label,
+            ),
+          )
+          .toList(),
+      selectedIndex: _selectedCategoryIndex,
+      onDestinationSelected: (index) {
+        setState(() => _selectedCategoryIndex = index);
+      },
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final metrics = _GridMetrics.fromWidth(constraints.maxWidth);
 
-          if (item['route'] == 'toggle_dark_mode') {
-            return Consumer<ThemeProvider>(
-              builder: (context, themeProvider, child) {
-                return _AdminMenuCard(
-                  title: item['title'],
-                  subtitle: item['subtitle'],
-                  icon: item['icon'],
-                  onTap: () {},
-                  trailingWidget: Switch(
-                    value: themeProvider.themeMode == ThemeMode.dark,
-                    onChanged: (value) {
-                      themeProvider.setTheme(
-                        value ? ThemeMode.dark : ThemeMode.light,
-                      );
-                    },
-                  ),
-                );
+            if (menuItems.isEmpty) {
+              return Center(
+                child: Text(
+                  'No tools available for this category yet.',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+              );
+            }
+
+            return GridView.builder(
+              padding: const EdgeInsets.all(16),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: metrics.crossAxisCount,
+                childAspectRatio: metrics.childAspectRatio,
+                crossAxisSpacing: 16,
+                mainAxisSpacing: 16,
+              ),
+              itemCount: menuItems.length,
+              itemBuilder: (context, index) {
+                final item = menuItems[index];
+                return _buildMenuCard(context, item, lowStockCount);
               },
             );
-          }
+          },
+        ),
+      ),
+    );
+  }
 
-          return badges.Badge(
-            showBadge: item['isSpecial'] == true && lowStockCount > 0,
-            badgeContent: Text(
-              lowStockCount.toString(),
-              style: const TextStyle(color: Colors.white),
-            ),
-            position: badges.BadgePosition.topEnd(top: 8, end: 8),
-            child: _AdminMenuCard(
-              title: item['title'],
-              subtitle: item['subtitle'],
-              icon: item['icon'],
-              isSpecial: item['isSpecial'] ?? false,
-              onTap: () {
-                if (item['route'] == 'add_expense_page') {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (ctx) => const AddExpensePage()),
-                  );
-                } else if (item['route'] == 'qr_generator_page') {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (ctx) => const QrGeneratorPage(),
-                    ),
-                  );
-                } else {
-                  context.push(item['route']);
-                }
+  Widget _buildMenuCard(
+    BuildContext context,
+    _AdminMenuItem item,
+    int lowStockCount,
+  ) {
+    if (item.isThemeToggle) {
+      return Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return _AdminMenuCard(
+            title: item.title,
+            subtitle: item.subtitle,
+            icon: item.icon,
+            onTap: () {},
+            trailingWidget: Switch(
+              value: themeProvider.themeMode == ThemeMode.dark,
+              onChanged: (value) {
+                themeProvider.setTheme(
+                  value ? ThemeMode.dark : ThemeMode.light,
+                );
               },
             ),
           );
         },
-      ),
+      );
+    }
+
+    final card = _AdminMenuCard(
+      title: item.title,
+      subtitle: item.subtitle,
+      icon: item.icon,
+      isSpecial: item.isSpecial,
+      onTap: () => _handleMenuTap(context, item),
     );
+
+    if (item.showLowStockBadge && lowStockCount > 0) {
+      return badges.Badge(
+        position: badges.BadgePosition.topEnd(top: 8, end: 8),
+        badgeContent: Text(
+          '$lowStockCount',
+          style: const TextStyle(color: Colors.white),
+        ),
+        child: card,
+      );
+    }
+
+    return card;
+  }
+
+  void _handleMenuTap(BuildContext context, _AdminMenuItem item) {
+    if (item.pageBuilder != null) {
+      Navigator.of(context).push(
+        MaterialPageRoute(builder: item.pageBuilder!),
+      );
+      return;
+    }
+
+    if (item.route != null) {
+      context.push(item.route!);
+    }
   }
 }
 
-class _AdminMenuCard extends StatelessWidget {
+class _GridMetrics {
+  const _GridMetrics({required this.crossAxisCount, required this.childAspectRatio});
+
+  final int crossAxisCount;
+  final double childAspectRatio;
+
+  static _GridMetrics fromWidth(double width) {
+    if (width < 600) {
+      return const _GridMetrics(crossAxisCount: 2, childAspectRatio: 1.0);
+    }
+    if (width < 1200) {
+      return const _GridMetrics(crossAxisCount: 3, childAspectRatio: 1.1);
+    }
+    return const _GridMetrics(crossAxisCount: 4, childAspectRatio: 1.0);
+  }
+}
+
+enum _AdminCategory { operations, inventory, insights, tools }
+
+extension on _AdminCategory {
+  String get label {
+    switch (this) {
+      case _AdminCategory.operations:
+        return 'Operations';
+      case _AdminCategory.inventory:
+        return 'Inventory';
+      case _AdminCategory.insights:
+        return 'Insights';
+      case _AdminCategory.tools:
+        return 'Tools';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case _AdminCategory.operations:
+        return Icons.dashboard_customize_outlined;
+      case _AdminCategory.inventory:
+        return Icons.inventory_2_outlined;
+      case _AdminCategory.insights:
+        return Icons.insights_outlined;
+      case _AdminCategory.tools:
+        return Icons.build_outlined;
+    }
+  }
+}
+
+class _AdminMenuItem {
+  const _AdminMenuItem({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.category,
+    required this.modes,
+    this.route,
+    this.pageBuilder,
+    this.isSpecial = false,
+    this.isThemeToggle = false,
+    this.showLowStockBadge = false,
+  }) : assert(
+            (route != null ? 1 : 0) +
+                    (pageBuilder != null ? 1 : 0) +
+                    (isThemeToggle ? 1 : 0) ==
+                1,
+          );
+
   final String title;
   final String subtitle;
   final IconData icon;
-  final VoidCallback onTap;
+  final _AdminCategory category;
+  final List<AppMode> modes;
+  final String? route;
+  final WidgetBuilder? pageBuilder;
   final bool isSpecial;
-  final Widget? trailingWidget;
+  final bool isThemeToggle;
+  final bool showLowStockBadge;
+}
 
+class _AdminMenuCard extends StatelessWidget {
   const _AdminMenuCard({
     required this.title,
     required this.subtitle,
@@ -302,6 +450,13 @@ class _AdminMenuCard extends StatelessWidget {
     this.isSpecial = false,
     this.trailingWidget,
   });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback onTap;
+  final bool isSpecial;
+  final Widget? trailingWidget;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/responsive_scaffold.dart
+++ b/lib/widgets/responsive_scaffold.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+/// A responsive scaffold that adapts the primary navigation pattern
+/// based on the available width.
+///
+/// * Compact layouts (< 600px) use a [NavigationBar] at the bottom.
+/// * Medium layouts (>= 600px and < 1024px) use a [NavigationRail].
+/// * Expanded layouts (>= 1024px) use a persistent [NavigationDrawer].
+class ResponsiveScaffold extends StatelessWidget {
+  const ResponsiveScaffold({
+    super.key,
+    required this.body,
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    this.appBar,
+    this.floatingActionButton,
+    this.floatingActionButtonLocation,
+  });
+
+  final Widget body;
+  final List<NavigationDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+  final PreferredSizeWidget? appBar;
+  final Widget? floatingActionButton;
+  final FloatingActionButtonLocation? floatingActionButtonLocation;
+
+  static const double _compactBreakpoint = 600;
+  static const double _mediumBreakpoint = 1024;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+
+    if (width < _compactBreakpoint) {
+      return _buildBottomNavigationScaffold(context);
+    }
+
+    if (width < _mediumBreakpoint) {
+      return _buildNavigationRailScaffold(context);
+    }
+
+    return _buildPersistentNavigationScaffold(context);
+  }
+
+  Widget _buildBottomNavigationScaffold(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: body,
+      floatingActionButton: floatingActionButton,
+      floatingActionButtonLocation: floatingActionButtonLocation,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: selectedIndex,
+        destinations: destinations,
+        onDestinationSelected: onDestinationSelected,
+      ),
+    );
+  }
+
+  Widget _buildNavigationRailScaffold(BuildContext context) {
+    final railDestinations = destinations
+        .map(
+          (destination) => NavigationRailDestination(
+            icon: destination.icon,
+            selectedIcon: destination.selectedIcon ?? destination.icon,
+            label: Text(destination.label),
+          ),
+        )
+        .toList();
+
+    return Scaffold(
+      appBar: appBar,
+      floatingActionButton: floatingActionButton,
+      floatingActionButtonLocation: floatingActionButtonLocation,
+      body: Row(
+        children: [
+          SafeArea(
+            child: NavigationRail(
+              selectedIndex: selectedIndex,
+              onDestinationSelected: onDestinationSelected,
+              labelType: NavigationRailLabelType.all,
+              destinations: railDestinations,
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPersistentNavigationScaffold(BuildContext context) {
+    final drawerDestinations = destinations
+        .map(
+          (destination) => NavigationDrawerDestination(
+            icon: destination.icon,
+            selectedIcon: destination.selectedIcon ?? destination.icon,
+            label: Text(destination.label),
+          ),
+        )
+        .toList();
+
+    return Scaffold(
+      appBar: appBar,
+      floatingActionButton: floatingActionButton,
+      floatingActionButtonLocation: floatingActionButtonLocation,
+      body: Row(
+        children: [
+          SafeArea(
+            child: NavigationDrawer(
+              selectedIndex: selectedIndex,
+              onDestinationSelected: onDestinationSelected,
+              children: [
+                const SizedBox(height: 12),
+                ...drawerDestinations,
+              ],
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable ResponsiveScaffold that swaps between bottom navigation, rail, and persistent drawer layouts based on width
- refactor the admin landing page to use the ResponsiveScaffold with categorized destinations and grid filtering

## Testing
- not run (Flutter tooling unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfd860c47883259485626a2c2abeb3