### PR TITLE
Add responsive FormFieldRow helper for form layouts

### DIFF
--- a/lib/add_purchase_order_page.dart
+++ b/lib/add_purchase_order_page.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:restaurant_models/restaurant_models.dart';
 
 import 'widgets/app_snack_bar.dart';
+import 'widgets/form_field_row.dart';
 // Helper class for a line item in the PO
 class PurchaseOrderItem {
   Ingredient ingredient;
@@ -207,9 +208,10 @@ class _AddPurchaseOrderPageState extends State<AddPurchaseOrderPage> {
                             ],
                           ),
                           const SizedBox(height: 8),
-                          Row(
+                          FormFieldRow(
+                            spacing: 16,
                             children: [
-                              Expanded(
+                              FormFieldRowChild(
                                 child: TextField(
                                   controller: poItem.quantityController,
                                   decoration: InputDecoration(
@@ -219,8 +221,7 @@ class _AddPurchaseOrderPageState extends State<AddPurchaseOrderPage> {
                                   keyboardType: TextInputType.number,
                                 ),
                               ),
-                              const SizedBox(width: 16),
-                              Expanded(
+                              FormFieldRowChild(
                                 child: TextField(
                                   controller: poItem.costController,
                                   decoration: const InputDecoration(

--- a/lib/admin/modifier_management_page.dart
+++ b/lib/admin/modifier_management_page.dart
@@ -2,6 +2,8 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/form_field_row.dart';
 // --- Data Models (Helper classes for this page) ---
 class ModifierOption {
   String optionName;
@@ -129,9 +131,10 @@ class _ModifierManagementPageState extends State<ModifierManagementPage> {
                     ...group.options.asMap().entries.map((entry) {
                       int index = entry.key;
                       ModifierOption option = entry.value;
-                      return Row(
+                      return FormFieldRow(
+                        spacing: 8,
                         children: [
-                          Expanded(
+                          FormFieldRowChild(
                             flex: 3,
                             child: TextFormField(
                               initialValue: option.optionName,
@@ -141,8 +144,7 @@ class _ModifierManagementPageState extends State<ModifierManagementPage> {
                               onChanged: (value) => option.optionName = value,
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          Expanded(
+                          FormFieldRowChild(
                             flex: 2,
                             child: TextFormField(
                               initialValue: option.priceChange.toString(),
@@ -154,20 +156,20 @@ class _ModifierManagementPageState extends State<ModifierManagementPage> {
                                   double.tryParse(value) ?? 0.0,
                             ),
                           ),
-                          IconButton(
-                            icon: const Icon(
-                              Icons.remove_circle_outline,
-                              color: Colors.red,
-                            ),
-                            onPressed: () {
-                              if (group.options.length > 1) {
-                                stfSetState(
-                                  () => group.options.removeAt(index),
-                                );
-                              }
-                            },
-                          ),
                         ],
+                        trailing: IconButton(
+                          icon: const Icon(
+                            Icons.remove_circle_outline,
+                            color: Colors.red,
+                          ),
+                          onPressed: () {
+                            if (group.options.length > 1) {
+                              stfSetState(
+                                () => group.options.removeAt(index),
+                              );
+                            }
+                          },
+                        ),
                       );
                     }).toList(),
                     TextButton.icon(

--- a/lib/admin/promotion_management_page.dart
+++ b/lib/admin/promotion_management_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:restaurant_models/restaurant_models.dart';
+
+import '../widgets/form_field_row.dart';
 class PromotionManagementPage extends StatefulWidget {
   const PromotionManagementPage({super.key});
 
@@ -404,17 +406,17 @@ class _PromotionManagementPageState extends State<PromotionManagementPage> {
                         }).toList(),
                       ),
                       const SizedBox(height: 16),
-                      Row(
+                      FormFieldRow(
+                        spacing: 12,
                         children: [
-                          Expanded(
+                          FormFieldRowChild(
                             child: buildTimeField(
                               label: 'Start Time (HH:MM)',
                               controller: startTimeController,
                               onPick: () => pickTime(isStart: true),
                             ),
                           ),
-                          const SizedBox(width: 12),
-                          Expanded(
+                          FormFieldRowChild(
                             child: buildTimeField(
                               label: 'End Time (HH:MM)',
                               controller: endTimeController,

--- a/lib/widgets/form_field_row.dart
+++ b/lib/widgets/form_field_row.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+/// A responsive row for arranging form fields without causing overflow.
+class FormFieldRow extends StatelessWidget {
+  const FormFieldRow({
+    super.key,
+    required this.children,
+    this.trailing,
+    this.spacing = 16,
+    this.verticalSpacing,
+    this.breakpoint = 520,
+    this.crossAxisAlignment = CrossAxisAlignment.start,
+  }) : assert(children.length > 0, 'FormFieldRow requires at least one child.');
+
+  /// The form field children to layout.
+  final List<FormFieldRowChild> children;
+
+  /// An optional trailing widget (e.g. an action button).
+  final Widget? trailing;
+
+  /// Horizontal spacing between children when laid out in a row.
+  final double spacing;
+
+  /// Vertical spacing between children when stacked.
+  final double? verticalSpacing;
+
+  /// The minimum width required to layout the children horizontally.
+  final double breakpoint;
+
+  /// The cross axis alignment when laid out horizontally.
+  final CrossAxisAlignment crossAxisAlignment;
+
+  @override
+  Widget build(BuildContext context) {
+    final verticalGap = verticalSpacing ?? spacing;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final isHorizontal = !maxWidth.isFinite || maxWidth >= breakpoint;
+
+        if (isHorizontal) {
+          final rowChildren = <Widget>[];
+          for (var i = 0; i < children.length; i++) {
+            if (i > 0) {
+              rowChildren.add(SizedBox(width: spacing));
+            }
+            final child = children[i];
+            rowChildren.add(
+              Expanded(
+                flex: child.flex,
+                child: child.child,
+              ),
+            );
+          }
+          if (trailing != null) {
+            if (rowChildren.isNotEmpty) {
+              rowChildren.add(SizedBox(width: spacing));
+            }
+            rowChildren.add(trailing!);
+          }
+          return Row(
+            crossAxisAlignment: crossAxisAlignment,
+            children: rowChildren,
+          );
+        }
+
+        final columnChildren = <Widget>[];
+        for (var i = 0; i < children.length; i++) {
+          if (i > 0) {
+            columnChildren.add(SizedBox(height: verticalGap));
+          }
+          columnChildren.add(children[i].child);
+        }
+        if (trailing != null) {
+          if (columnChildren.isNotEmpty) {
+            columnChildren.add(SizedBox(height: verticalGap));
+          }
+          columnChildren.add(
+            Align(
+              alignment: Alignment.centerRight,
+              child: trailing,
+            ),
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: columnChildren,
+        );
+      },
+    );
+  }
+}
+
+/// Describes an individual child within a [FormFieldRow].
+class FormFieldRowChild {
+  const FormFieldRowChild({
+    required this.child,
+    this.flex = 1,
+  }) : assert(flex > 0, 'flex must be greater than zero.');
+
+  /// The widget to render for this child.
+  final Widget child;
+
+  /// The flex factor when laid out horizontally.
+  final int flex;
+}


### PR DESCRIPTION
## Summary
- add a reusable FormFieldRow widget that adapts form field rows between horizontal and vertical layouts
- switch purchase order, promotion, and modifier dialogs to use FormFieldRow to prevent overflow on narrow screens

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdb2001408325bae15895e5f4fba9