### PR TITLE
Fix checkout success navigation to floor plan

### DIFF
--- a/lib/checkout_page.dart
+++ b/lib/checkout_page.dart
@@ -1533,7 +1533,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(successMessage)));
-    context.go('/order-type-selection');
+    context.go('/floorplan');
   }
 
   @override


### PR DESCRIPTION
## Summary
- update the checkout success handler to send staff back to the floor plan view after payment confirmation

## Testing
- `flutter test` *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe9cce8948325a1c6297d0016abcb