### PR TITLE
Fix customer checkout navigation after payment

### DIFF
--- a/lib/customer_checkout_page.dart
+++ b/lib/customer_checkout_page.dart
@@ -143,7 +143,8 @@ class _CustomerCheckoutPageState extends State<CustomerCheckoutPage> {
               TextButton(
                 child: const Text('OK'),
                 onPressed: () {
-                  Navigator.of(ctx).popUntil((route) => route.isFirst);
+                  Navigator.of(ctx).pop();
+                  Navigator.of(context).popUntil((route) => route.isFirst);
                 },
               ),
             ],


### PR DESCRIPTION
## Summary
- ensure the customer checkout confirmation dialog closes before navigating
- return users to the first route after confirming payment so they can continue using the app

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfeeb210408325958448485dfa8391