### PR TITLE
Add Omise payment gateway support

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -600,7 +600,7 @@ packages:
     source: hosted
     version: "0.15.6"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   cloud_functions: ^5.0.3
   image_picker: ^1.1.2
   mobile_scanner: ^5.1.1
+  http: ^1.2.1
   audioplayers: ^6.0.0
   rxdart: ^0.28.0
   connectivity_plus: ^6.0.3


### PR DESCRIPTION
## Summary
- add an Omise payment gateway option and adapter with REST integration and robust error handling
- bootstrap Omise configuration from Remote Config during application startup
- add the http dependency needed to call the Omise APIs

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e146cbf5d483259074a96129b4acb9