### PR TITLE
docs: document Firebase secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ await featureFlagProvider.configureReleaseChannel(
 );
 ```
 
+## Secrets & backend environment variables
+
+Cloud Functions rely on a mix of environment variables and Google Secret Manager
+entries for third-party integrations such as SendGrid and the synthetic monitor.
+The `functions/.env.example` template lists every variable consumed via
+`process.env`. Follow the [Firebase Functions README](functions/README.md) to:
+
+- create a local `.env` file for emulator runs,
+- publish non-sensitive values with `firebase deploy --env-vars-file`, and
+- register secrets (`SENDGRID_API_KEY`, `SYNTHETIC_MONITOR_BEARER_TOKEN`, etc.)
+  with `firebase functions:secrets:set`.
+
+Without these values the scheduled monitor, backup exports, and email delivery
+will fail fast during deployment.
+
 With the channel cleared, affected stores fall back to the default production
 flags without shipping a new build.
 

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,0 +1,38 @@
+# Copy this file to `.env` and fill in the values before deploying Cloud Functions.
+# Values marked as optional can be left blank to fall back to the defaults used in
+# the source code. Secrets should be kept out of version control.
+
+# === Storage & analytics configuration ===
+# Optional: Cloud Storage bucket that will receive scheduled exports and backups.
+BACKUP_BUCKET=
+
+# Optional: BigQuery dataset and table names for analytics streaming.
+BIGQUERY_DATASET=restaurant_analytics
+BIGQUERY_TABLE_ANALYTICS_ORDERS=orders_stream
+BIGQUERY_TABLE_ANALYTICS_CUSTOMERS=customers_stream
+BIGQUERY_TABLE_ANALYTICS_REFUNDS=refunds_stream
+
+# Optional: BigQuery dataset/table for build performance metrics.
+BUILD_METRICS_DATASET=ops_metrics
+BUILD_METRICS_TABLE=frame_performance
+
+# === Synthetic monitor ===
+# Required when enabling the synthetic monitor scheduled function.
+SYNTHETIC_MONITOR_TARGET=
+# Optional bearer token that will be sent as the Authorization header.
+SYNTHETIC_MONITOR_BEARER_TOKEN=
+# Comma separated list of HTTP status codes that are considered successful.
+SYNTHETIC_MONITOR_EXPECTED_STATUS_CODES=200
+# Optional substring that must be present in the response body.
+SYNTHETIC_MONITOR_EXPECTED_SUBSTRING=
+# Cron schedule and timezone for the monitor. Defaults match the code fallback.
+SYNTHETIC_MONITOR_SCHEDULE=*/15 * * * *
+SYNTHETIC_MONITOR_TIMEZONE=Asia/Bangkok
+# Override the HTTP timeout in milliseconds.
+SYNTHETIC_MONITOR_TIMEOUT_MS=5000
+
+# === Outbound email ===
+# SendGrid API key used by transactional email functions. Treat as secret.
+SENDGRID_API_KEY=
+# Optional custom "from" address for SendGrid.
+SENDGRID_FROM_EMAIL=no-reply@restaurant.local

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,81 @@
+# Firebase Functions
+
+This workspace hosts the backend automation for the Restaurant App POS. In
+addition to installing the Node dependencies (`npm ci`), a handful of runtime
+secrets and environment variables must be configured before deploying to a real
+Firebase project.
+
+## 1. Install dependencies
+
+```bash
+npm --prefix functions ci
+```
+
+## 2. Create an environment file
+
+Copy the provided template and fill in the values for your environment. Secrets
+(such as API keys) should never be committed to version control.
+
+```bash
+cp functions/.env.example functions/.env
+# Edit functions/.env to add project specific values
+```
+
+The template documents every variable that `process.env` expects. Required
+values include:
+
+- `SENDGRID_API_KEY` – SendGrid credential used by transactional emails
+- `SYNTHETIC_MONITOR_TARGET` – URL probed by the synthetic monitor cron job
+- Optional `SYNTHETIC_MONITOR_BEARER_TOKEN` if the endpoint requires auth
+- Storage/BQ identifiers (`BACKUP_BUCKET`, `BIGQUERY_*`, `BUILD_METRICS_*`)
+
+## 3. Load variables locally
+
+The Firebase emulator reads environment variables from the current shell. Source
+the `.env` file before running the emulator or Vitest suite:
+
+```bash
+export $(grep -v '^#' functions/.env | xargs)
+npm --prefix functions run serve
+```
+
+On macOS you may need to replace `export $(...)` with `set -a; source
+functions/.env; set +a` to ensure variables with spaces are loaded correctly.
+
+## 4. Store secrets in Firebase
+
+Firebase Functions (2nd gen) supports both plain environment variables and
+Secret Manager entries. We recommend pushing non-sensitive values with the
+`--env-vars-file` flag and storing sensitive credentials as secrets.
+
+```bash
+# Push non-sensitive values (bucket names, dataset IDs, schedules)
+firebase deploy \
+  --only functions \
+  --project <project-id> \
+  --env-vars-file functions/.env \
+  --config firebase.json
+```
+
+For secrets like `SENDGRID_API_KEY` and `SYNTHETIC_MONITOR_BEARER_TOKEN` use the
+Secret Manager integration. The template comments mark these entries.
+
+```bash
+firebase functions:secrets:set SENDGRID_API_KEY --project <project-id> < <( \
+  grep '^SENDGRID_API_KEY=' functions/.env | cut -d'=' -f2-
+)
+
+firebase functions:secrets:set SYNTHETIC_MONITOR_BEARER_TOKEN --project <project-id> < <( \
+  grep '^SYNTHETIC_MONITOR_BEARER_TOKEN=' functions/.env | cut -d'=' -f2-
+)
+```
+
+Secrets can be audited with `firebase functions:secrets:list` and rotated by
+running the same command with a new value. The next deployment automatically
+links the latest secret version to every function.
+
+## 5. Verify deployment
+
+After deploying, inspect the configuration from the Firebase console or with
+`firebase functions:config:get`. Scheduled monitors and email delivery will fail
+fast with descriptive logs if required secrets are missing.


### PR DESCRIPTION
## Summary
- add a `.env` template that lists all Cloud Functions environment variables and secrets
- document how to load the env file locally and push secrets to Firebase
- reference the new guidance from the root README so developers can find it easily

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e6071d9624832593d01be83585c303