### PR TITLE
feat(functions): add Omise charges API

### DIFF
--- a/functions/src/payments/omiseApi.ts
+++ b/functions/src/payments/omiseApi.ts
@@ -1,0 +1,399 @@
+import {
+  createOmiseClient,
+  type OmiseChargeRequest,
+  type OmiseClient,
+  type OmiseClientConfig,
+  type OmiseRefundRequest,
+  type OmiseRequestOptions,
+  type OmiseResponse,
+  type OmiseSourceRequest,
+} from "./omiseClient.js";
+
+export interface OmiseCard3dsChargeParams extends BaseChargeParams {
+  cardToken: string;
+  returnUri: string;
+}
+
+export interface OmisePromptPayChargeParams extends SourceChargeParams {
+  sourceMetadata?: Record<string, unknown>;
+  sourceData?: Record<string, unknown>;
+}
+
+export interface OmiseMobileBankingChargeParams extends SourceChargeParams {
+  bank?: string;
+  sourceType?: string;
+  sourceMetadata?: Record<string, unknown>;
+  sourceData?: Record<string, unknown>;
+}
+
+export interface OmiseRefundChargeParams {
+  amount?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OmiseChargeResult {
+  charge: OmiseResponse;
+  source?: OmiseResponse;
+}
+
+export interface OmiseSourceChargeOptions {
+  source?: OmiseRequestOptions;
+  charge?: OmiseRequestOptions;
+}
+
+export interface OmiseChargesApi {
+  createCardCharge3ds(
+    params: OmiseCard3dsChargeParams,
+    options?: OmiseRequestOptions
+  ): Promise<OmiseChargeResult>;
+  createPromptPayCharge(
+    params: OmisePromptPayChargeParams,
+    options?: OmiseSourceChargeOptions
+  ): Promise<OmiseChargeResult>;
+  createMobileBankingCharge(
+    params: OmiseMobileBankingChargeParams,
+    options?: OmiseSourceChargeOptions
+  ): Promise<OmiseChargeResult>;
+  captureCharge(
+    chargeId: string,
+    options?: OmiseRequestOptions
+  ): Promise<OmiseResponse>;
+  refundCharge(
+    chargeId: string,
+    payload?: OmiseRefundChargeParams,
+    options?: OmiseRequestOptions
+  ): Promise<OmiseResponse>;
+}
+
+export class OmiseApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OmiseApiError";
+  }
+}
+
+type OmiseChargesInit = OmiseClientConfig | {client: OmiseClient};
+
+export function createOmiseChargesApi(
+  config: OmiseChargesInit
+): OmiseChargesApi {
+  const client = hasClient(config)
+    ? config.client
+    : createOmiseClient(config);
+
+  return {
+    async createCardCharge3ds(params, options) {
+      const amount = ensurePositiveInteger(params.amount, "amount");
+      const currency = normalizeCurrency(params.currency);
+      const cardToken = ensureNonEmptyString(params.cardToken, "cardToken");
+      const returnUri = ensureNonEmptyString(params.returnUri, "returnUri");
+
+      const chargePayload = buildChargePayload(
+        params,
+        amount,
+        currency,
+        {
+          card: cardToken,
+          return_uri: returnUri,
+        }
+      );
+
+      const charge = await client.createCharge(chargePayload, options);
+      return {charge};
+    },
+
+    async createPromptPayCharge(params, options) {
+      const amount = ensurePositiveInteger(params.amount, "amount");
+      const currency = normalizeCurrency(params.currency);
+
+      const sourcePayload = buildSourcePayload(
+        params,
+        amount,
+        currency,
+        "promptpay",
+        params.sourceMetadata,
+        params.sourceData
+      );
+
+      const source = await client.createSource(sourcePayload, options?.source);
+      const sourceId = extractIdentifier(source, "source");
+
+      const chargePayload = buildChargePayload(
+        params,
+        amount,
+        currency,
+        {
+          source: sourceId,
+        }
+      );
+
+      const charge = await client.createCharge(chargePayload, options?.charge);
+      return {charge, source};
+    },
+
+    async createMobileBankingCharge(params, options) {
+      const amount = ensurePositiveInteger(params.amount, "amount");
+      const currency = normalizeCurrency(params.currency);
+      const sourceType = resolveMobileBankingType(params);
+
+      const sourcePayload = buildSourcePayload(
+        params,
+        amount,
+        currency,
+        sourceType,
+        params.sourceMetadata,
+        params.sourceData
+      );
+
+      const source = await client.createSource(sourcePayload, options?.source);
+      const sourceId = extractIdentifier(source, "source");
+
+      const chargePayload = buildChargePayload(
+        params,
+        amount,
+        currency,
+        {
+          source: sourceId,
+        }
+      );
+
+      const charge = await client.createCharge(chargePayload, options?.charge);
+      return {charge, source};
+    },
+
+    captureCharge(chargeId, options) {
+      const id = ensureNonEmptyString(chargeId, "chargeId");
+      return client.captureCharge(id, options);
+    },
+
+    refundCharge(chargeId, payload, options) {
+      const id = ensureNonEmptyString(chargeId, "chargeId");
+      const normalized = normalizeRefundPayload(payload);
+      return client.refundCharge(id, normalized, options);
+    },
+  };
+}
+
+function hasClient(config: OmiseChargesInit): config is {client: OmiseClient} {
+  return (config as {client?: OmiseClient}).client !== undefined;
+}
+
+interface BaseChargeParams {
+  amount: number;
+  currency: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  capture?: boolean;
+  customerId?: string;
+}
+
+interface SourceChargeParams extends BaseChargeParams {
+  email?: string;
+  name?: string;
+  phoneNumber?: string;
+}
+
+function buildChargePayload(
+  params: BaseChargeParams,
+  amount: number,
+  currency: string,
+  extra: Record<string, unknown>
+): OmiseChargeRequest {
+  const payload: Record<string, unknown> = {
+    amount,
+    currency,
+    ...extra,
+  };
+
+  const description = coerceOptionalString(params.description);
+  if (description) {
+    payload.description = description;
+  }
+
+  const metadata = sanitizeRecord(params.metadata);
+  if (metadata) {
+    payload.metadata = metadata;
+  }
+
+  if (params.capture !== undefined) {
+    payload.capture = params.capture;
+  }
+
+  const customer = coerceOptionalString(params.customerId);
+  if (customer) {
+    payload.customer = customer;
+  }
+
+  return payload as OmiseChargeRequest;
+}
+
+function buildSourcePayload(
+  params: SourceChargeParams,
+  amount: number,
+  currency: string,
+  type: string,
+  metadata?: Record<string, unknown>,
+  additionalData?: Record<string, unknown>
+): OmiseSourceRequest {
+  const payload: Record<string, unknown> = {
+    type,
+    amount,
+    currency,
+  };
+
+  const normalizedMetadata = sanitizeRecord(metadata);
+  if (normalizedMetadata) {
+    payload.metadata = normalizedMetadata;
+  }
+
+  const email = coerceOptionalString(params.email);
+  if (email) {
+    payload.email = email;
+  }
+
+  const name = coerceOptionalString(params.name);
+  if (name) {
+    payload.name = name;
+  }
+
+  const phoneNumber = coerceOptionalString(params.phoneNumber);
+  if (phoneNumber) {
+    payload.phone_number = phoneNumber;
+  }
+
+  if (additionalData) {
+    for (const [key, value] of Object.entries(additionalData)) {
+      if (value === undefined || isReservedSourceKey(key)) {
+        continue;
+      }
+      payload[key] = value;
+    }
+  }
+
+  return payload as OmiseSourceRequest;
+}
+
+function normalizeRefundPayload(
+  payload?: OmiseRefundChargeParams
+): OmiseRefundRequest | undefined {
+  if (!payload) {
+    return undefined;
+  }
+
+  const normalized: Record<string, unknown> = {};
+
+  if (payload.amount !== undefined) {
+    normalized.amount = ensurePositiveInteger(payload.amount, "amount");
+  }
+
+  const metadata = sanitizeRecord(payload.metadata);
+  if (metadata) {
+    normalized.metadata = metadata;
+  }
+
+  return normalized as OmiseRefundRequest;
+}
+
+function ensurePositiveInteger(value: number, field: string): number {
+  if (!Number.isFinite(value)) {
+    throw new OmiseApiError(`${field} must be a finite number.`);
+  }
+  if (!Number.isInteger(value)) {
+    throw new OmiseApiError(
+      `${field} must be an integer representing the smallest currency unit.`
+    );
+  }
+  if (value <= 0) {
+    throw new OmiseApiError(`${field} must be greater than zero.`);
+  }
+  return value;
+}
+
+function ensureNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new OmiseApiError(`${field} must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new OmiseApiError(`${field} must not be empty.`);
+  }
+  return trimmed;
+}
+
+function normalizeCurrency(value: string): string {
+  const normalized = ensureNonEmptyString(value, "currency").toLowerCase();
+  if (!/^[a-z]{3}$/.test(normalized)) {
+    throw new OmiseApiError("currency must be a three-letter ISO code.");
+  }
+  return normalized;
+}
+
+function resolveMobileBankingType(
+  params: OmiseMobileBankingChargeParams
+): string {
+  if (params.sourceType) {
+    return ensureIdentifier(params.sourceType, "sourceType");
+  }
+  if (!params.bank) {
+    throw new OmiseApiError(
+      "bank is required when sourceType is not provided for mobile banking charges."
+    );
+  }
+  const bank = ensureIdentifier(params.bank, "bank");
+  return `mobile_banking_${bank}`;
+}
+
+function ensureIdentifier(value: string, field: string): string {
+  const normalized = ensureNonEmptyString(value, field).toLowerCase();
+  if (!/^[a-z0-9_]+$/.test(normalized)) {
+    throw new OmiseApiError(
+      `${field} may only contain lowercase letters, numbers, or underscores.`
+    );
+  }
+  return normalized;
+}
+
+function coerceOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function sanitizeRecord(
+  data?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!data) {
+    return undefined;
+  }
+  const entries = Object.entries(data).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries);
+}
+
+function extractIdentifier(response: OmiseResponse, label: string): string {
+  const id = response?.["id"];
+  if (typeof id !== "string" || id.trim() === "") {
+    throw new OmiseApiError(`Omise ${label} did not return an identifier.`);
+  }
+  return id;
+}
+
+function isReservedSourceKey(key: string): boolean {
+  switch (key) {
+    case "type":
+    case "amount":
+    case "currency":
+    case "metadata":
+    case "email":
+    case "name":
+    case "phone_number":
+      return true;
+    default:
+      return false;
+  }
+}
+

--- a/functions/src/payments/omiseClient.ts
+++ b/functions/src/payments/omiseClient.ts
@@ -98,6 +98,10 @@ export interface OmiseClient {
     chargeId: string,
     options?: OmiseRequestOptions
   ): Promise<OmiseResponse>;
+  captureCharge(
+    chargeId: string,
+    options?: OmiseRequestOptions
+  ): Promise<OmiseResponse>;
   refundCharge(
     chargeId: string,
     payload?: OmiseRefundRequest,
@@ -204,6 +208,13 @@ export function createOmiseClient(config: OmiseClientConfig): OmiseClient {
         ...options,
         method: options?.method ?? "GET",
       });
+    },
+    captureCharge(chargeId, options) {
+      return requestWithSecretKey(
+        `/charges/${encodeURIComponent(chargeId)}/capture`,
+        undefined,
+        options
+      );
     },
     refundCharge(chargeId, payload, options) {
       return requestWithSecretKey(

--- a/functions/tests/omiseApi.test.ts
+++ b/functions/tests/omiseApi.test.ts
@@ -1,0 +1,252 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import {
+  createOmiseChargesApi,
+  OmiseApiError,
+  type OmiseChargeResult,
+} from "../src/payments/omiseApi.js";
+import type {OmiseClient, OmiseResponse} from "../src/payments/omiseClient.js";
+
+describe("createOmiseChargesApi", () => {
+  let client: OmiseClient;
+  let createSource: ReturnType<typeof vi.fn>;
+  let createCharge: ReturnType<typeof vi.fn>;
+  let captureCharge: ReturnType<typeof vi.fn>;
+  let refundCharge: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createSource = vi.fn();
+    createCharge = vi.fn();
+    captureCharge = vi.fn();
+    refundCharge = vi.fn();
+
+    client = {
+      createSource: createSource as unknown as OmiseClient["createSource"],
+      createCharge: createCharge as unknown as OmiseClient["createCharge"],
+      retrieveCharge: vi.fn(),
+      captureCharge: captureCharge as unknown as OmiseClient["captureCharge"],
+      refundCharge: refundCharge as unknown as OmiseClient["refundCharge"],
+    };
+  });
+
+  describe("createCardCharge3ds", () => {
+    it("builds a charge payload for 3DS card payments", async () => {
+      const chargeResponse: OmiseResponse = {
+        id: "chrg_test",
+        authorize_uri: "https://example.com/authorize",
+      };
+      createCharge.mockResolvedValue(chargeResponse);
+
+      const api = createOmiseChargesApi({client});
+      const result = await api.createCardCharge3ds(
+        {
+          amount: 10500,
+          currency: "THB",
+          cardToken: "tokn_test",
+          returnUri: "https://example.com/return",
+          description: "Table #12",
+          metadata: {orderId: "order-12"},
+          capture: false,
+          customerId: "cust_test",
+        },
+        {idempotencyKey: "card-charge"}
+      );
+
+      expect(createCharge).toHaveBeenCalledWith(
+        {
+          amount: 10500,
+          currency: "thb",
+          card: "tokn_test",
+          return_uri: "https://example.com/return",
+          description: "Table #12",
+          metadata: {orderId: "order-12"},
+          capture: false,
+          customer: "cust_test",
+        },
+        {idempotencyKey: "card-charge"}
+      );
+      expect(result).toEqual<OmiseChargeResult>({charge: chargeResponse});
+    });
+
+    it("rejects non-integer amounts", async () => {
+      const api = createOmiseChargesApi({client});
+
+      await expect(
+        api.createCardCharge3ds({
+          amount: 100.5,
+          currency: "THB",
+          cardToken: "tokn_test",
+          returnUri: "https://example.com/return",
+        })
+      ).rejects.toThrowError(OmiseApiError);
+    });
+  });
+
+  describe("createPromptPayCharge", () => {
+    it("creates a source and charge", async () => {
+      const sourceResponse: OmiseResponse = {id: "src_promptpay"};
+      const chargeResponse: OmiseResponse = {id: "chrg_promptpay"};
+      createSource.mockResolvedValue(sourceResponse);
+      createCharge.mockResolvedValue(chargeResponse);
+
+      const api = createOmiseChargesApi({client});
+      const result = await api.createPromptPayCharge(
+        {
+          amount: 2500,
+          currency: "THB",
+          description: "Takeaway order",
+          metadata: {orderId: "order-42"},
+          sourceMetadata: {channel: "qr"},
+          email: "guest@example.com",
+          name: "Guest",
+          phoneNumber: "+669999999",
+        },
+        {
+          source: {idempotencyKey: "source"},
+          charge: {idempotencyKey: "charge"},
+        }
+      );
+
+      expect(createSource).toHaveBeenCalledWith(
+        {
+          type: "promptpay",
+          amount: 2500,
+          currency: "thb",
+          metadata: {channel: "qr"},
+          email: "guest@example.com",
+          name: "Guest",
+          phone_number: "+669999999",
+        },
+        {idempotencyKey: "source"}
+      );
+      expect(createCharge).toHaveBeenCalledWith(
+        {
+          amount: 2500,
+          currency: "thb",
+          source: "src_promptpay",
+          description: "Takeaway order",
+          metadata: {orderId: "order-42"},
+        },
+        {idempotencyKey: "charge"}
+      );
+      expect(result).toEqual<OmiseChargeResult>({
+        charge: chargeResponse,
+        source: sourceResponse,
+      });
+    });
+
+    it("throws when Omise does not return a source identifier", async () => {
+      createSource.mockResolvedValue({});
+
+      const api = createOmiseChargesApi({client});
+
+      await expect(
+        api.createPromptPayCharge({amount: 1000, currency: "THB"})
+      ).rejects.toThrowError(/identifier/i);
+    });
+  });
+
+  describe("createMobileBankingCharge", () => {
+    it("builds requests with a resolved mobile banking type", async () => {
+      const sourceResponse: OmiseResponse = {id: "src_mobile"};
+      const chargeResponse: OmiseResponse = {id: "chrg_mobile"};
+      createSource.mockResolvedValue(sourceResponse);
+      createCharge.mockResolvedValue(chargeResponse);
+
+      const api = createOmiseChargesApi({client});
+      await api.createMobileBankingCharge(
+        {
+          amount: 8900,
+          currency: "THB",
+          bank: "SCB",
+          sourceMetadata: {channel: "app"},
+          sourceData: {platform_type: "ios"},
+        },
+        {charge: {idempotencyKey: "mobile"}}
+      );
+
+      expect(createSource).toHaveBeenCalledWith(
+        {
+          type: "mobile_banking_scb",
+          amount: 8900,
+          currency: "thb",
+          metadata: {channel: "app"},
+          platform_type: "ios",
+        },
+        undefined
+      );
+      expect(createCharge).toHaveBeenCalledWith(
+        {
+          amount: 8900,
+          currency: "thb",
+          source: "src_mobile",
+        },
+        {idempotencyKey: "mobile"}
+      );
+    });
+
+    it("validates the mobile banking bank identifier", async () => {
+      const api = createOmiseChargesApi({client});
+
+      await expect(
+        api.createMobileBankingCharge({
+          amount: 1000,
+          currency: "THB",
+          bank: "",
+        })
+      ).rejects.toThrowError(OmiseApiError);
+    });
+  });
+
+  describe("captureCharge", () => {
+    it("delegates to the Omise client", async () => {
+      const captureResponse: OmiseResponse = {id: "chrg_capture"};
+      captureCharge.mockResolvedValue(captureResponse);
+
+      const api = createOmiseChargesApi({client});
+      await expect(api.captureCharge("chrg_capture", {idempotencyKey: "cap"}))
+        .resolves.toEqual(captureResponse);
+
+      expect(captureCharge).toHaveBeenCalledWith("chrg_capture", {
+        idempotencyKey: "cap",
+      });
+    });
+  });
+
+  describe("refundCharge", () => {
+    it("normalizes the refund payload", async () => {
+      const refundResponse: OmiseResponse = {id: "rfnd_test"};
+      refundCharge.mockResolvedValue(refundResponse);
+
+      const api = createOmiseChargesApi({client});
+      await expect(
+        api.refundCharge(
+          "chrg_test",
+          {
+            amount: 5000,
+            metadata: {reason: "customer_request", notes: undefined},
+          },
+          {idempotencyKey: "rfnd"}
+        )
+      ).resolves.toEqual(refundResponse);
+
+      expect(refundCharge).toHaveBeenCalledWith(
+        "chrg_test",
+        {
+          amount: 5000,
+          metadata: {reason: "customer_request"},
+        },
+        {idempotencyKey: "rfnd"}
+      );
+    });
+
+    it("rejects invalid refund amounts", async () => {
+      const api = createOmiseChargesApi({client});
+
+      await expect(
+        api.refundCharge("chrg_test", {amount: -1})
+      ).rejects.toThrowError(OmiseApiError);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a dedicated Omise charges API that drives card 3DS, PromptPay, and mobile banking flows and delegates capture/refund handling
- extend the Omise client with a capture helper so the new API can finalize authorized charges
- cover the new API with unit tests to verify payload construction and error handling

## Testing
- npm --prefix functions test *(fails: vitest executable unavailable because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e60de242bc8325b1c044813f16c399