### PR TITLE
Add Omise webhook charge confirmation handler

### DIFF
--- a/functions/src/payments/omiseWebhook.ts
+++ b/functions/src/payments/omiseWebhook.ts
@@ -1,0 +1,68 @@
+import type {OmiseClient, OmiseResponse} from "./omiseClient.js";
+
+export interface OmiseWebhookEvent {
+  key?: string;
+  data?: OmiseWebhookCharge | null;
+  [key: string]: unknown;
+}
+
+export interface OmiseWebhookCharge {
+  object?: string;
+  id?: string;
+  [key: string]: unknown;
+}
+
+export interface OmiseWebhookResult {
+  handled: boolean;
+  event: OmiseWebhookEvent;
+  charge?: OmiseResponse;
+}
+
+export class OmiseWebhookError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OmiseWebhookError";
+  }
+}
+
+export async function handleOmiseWebhookEvent(
+  event: OmiseWebhookEvent | null | undefined,
+  client: Pick<OmiseClient, "retrieveCharge">
+): Promise<OmiseWebhookResult> {
+  if (!event || typeof event !== "object") {
+    throw new OmiseWebhookError("Omise webhook payload must be an object.");
+  }
+
+  if (event.key !== "charge.complete") {
+    return {handled: false, event};
+  }
+
+  const charge = event.data;
+  if (!charge || typeof charge !== "object") {
+    throw new OmiseWebhookError(
+      "Omise charge.complete webhook payload is missing charge data."
+    );
+  }
+
+  if (charge.object !== undefined && charge.object !== "charge") {
+    throw new OmiseWebhookError(
+      "Omise charge.complete webhook payload did not include a charge object."
+    );
+  }
+
+  const chargeId = charge.id;
+  if (typeof chargeId !== "string" || chargeId.trim() === "") {
+    throw new OmiseWebhookError(
+      "Omise charge.complete webhook payload did not include a charge id."
+    );
+  }
+
+  const normalizedChargeId = chargeId.trim();
+  const retrievedCharge = await client.retrieveCharge(normalizedChargeId);
+
+  return {
+    handled: true,
+    event,
+    charge: retrievedCharge,
+  };
+}

--- a/functions/tests/omiseWebhook.test.ts
+++ b/functions/tests/omiseWebhook.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it, vi} from "vitest";
+
+import {
+  handleOmiseWebhookEvent,
+  OmiseWebhookError,
+  type OmiseWebhookEvent,
+} from "../src/payments/omiseWebhook.js";
+import type {OmiseClient} from "../src/payments/omiseClient.js";
+
+describe("handleOmiseWebhookEvent", () => {
+  const createClient = () => {
+    const retrieveCharge = vi.fn();
+    const client = {
+      createSource: vi.fn(),
+      createCharge: vi.fn(),
+      retrieveCharge: retrieveCharge as unknown as OmiseClient["retrieveCharge"],
+      captureCharge: vi.fn(),
+      refundCharge: vi.fn(),
+    } as unknown as OmiseClient;
+
+    return {client, retrieveCharge};
+  };
+
+  it("retrieves the charge again when receiving charge.complete", async () => {
+    const {client, retrieveCharge} = createClient();
+    retrieveCharge.mockResolvedValue({id: "chrg_test"});
+
+    const event: OmiseWebhookEvent = {
+      key: "charge.complete",
+      data: {object: "charge", id: " chrg_test "},
+    };
+
+    const result = await handleOmiseWebhookEvent(event, client);
+
+    expect(retrieveCharge).toHaveBeenCalledWith("chrg_test");
+    expect(result).toEqual({
+      handled: true,
+      event,
+      charge: {id: "chrg_test"},
+    });
+  });
+
+  it("ignores events other than charge.complete", async () => {
+    const {client, retrieveCharge} = createClient();
+
+    const event: OmiseWebhookEvent = {
+      key: "charge.failed",
+      data: {object: "charge", id: "chrg_test"},
+    };
+
+    const result = await handleOmiseWebhookEvent(event, client);
+
+    expect(result).toEqual({handled: false, event});
+    expect(retrieveCharge).not.toHaveBeenCalled();
+  });
+
+  it("throws when charge.complete payload does not include a charge id", async () => {
+    const {client} = createClient();
+
+    await expect(
+      handleOmiseWebhookEvent(
+        {
+          key: "charge.complete",
+          data: {object: "charge"},
+        },
+        client
+      )
+    ).rejects.toThrow(OmiseWebhookError);
+  });
+});


### PR DESCRIPTION
## Summary
- add a webhook helper that validates Omise charge.complete events
- re-fetch the charge through the Omise client to confirm completion
- cover the webhook workflow with unit tests

## Testing
- npm test -- omiseWebhook.test.ts *(fails: vitest is unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6103a439883259d0c63b9834cb81b