### PR TITLE
Add payment redirect handling for 3DS and mobile banking flows

### DIFF
--- a/lib/widgets/payment_redirect_page.dart
+++ b/lib/widgets/payment_redirect_page.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Helper that presents a WebView or deep link to complete payment
+/// authorizations such as 3-D Secure or mobile banking flows.
+class PaymentRedirectLauncher {
+  const PaymentRedirectLauncher._();
+
+  /// Opens a new page that navigates to [url] so the user can
+  /// complete an external payment step. If the URL uses a non-http(s)
+  /// scheme, the method attempts to launch it externally instead of
+  /// displaying a WebView.
+  static Future<bool> open({
+    required BuildContext context,
+    required Uri url,
+    String? title,
+    String? description,
+  }) async {
+    if (!context.mounted) {
+      return false;
+    }
+
+    if (!_isHttpScheme(url)) {
+      return _launchExternal(context, url);
+    }
+
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        fullscreenDialog: true,
+        builder: (_) => _PaymentRedirectPage(
+          initialUrl: url,
+          title: title,
+          description: description,
+        ),
+      ),
+    );
+
+    return result ?? true;
+  }
+
+  static bool _isHttpScheme(Uri uri) {
+    final scheme = uri.scheme.toLowerCase();
+    return scheme == 'http' || scheme == 'https';
+  }
+
+  static Future<bool> _launchExternal(BuildContext context, Uri uri) async {
+    try {
+      final launched = await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!launched && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('ไม่สามารถเปิดลิงก์ ${uri.toString()} ได้'),
+          ),
+        );
+      }
+      return launched;
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('เกิดข้อผิดพลาดในการเปิดลิงก์: $error'),
+          ),
+        );
+      }
+      return false;
+    }
+  }
+}
+
+class _PaymentRedirectPage extends StatefulWidget {
+  const _PaymentRedirectPage({
+    required this.initialUrl,
+    this.title,
+    this.description,
+  });
+
+  final Uri initialUrl;
+  final String? title;
+  final String? description;
+
+  @override
+  State<_PaymentRedirectPage> createState() => _PaymentRedirectPageState();
+}
+
+class _PaymentRedirectPageState extends State<_PaymentRedirectPage> {
+  late final WebViewController _controller;
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (_) {
+            if (mounted) {
+              setState(() {
+                _isLoading = true;
+                _errorMessage = null;
+              });
+            }
+          },
+          onPageFinished: (_) {
+            if (mounted) {
+              setState(() {
+                _isLoading = false;
+              });
+            }
+          },
+          onWebResourceError: (error) {
+            if (mounted) {
+              setState(() {
+                _isLoading = false;
+                _errorMessage = error.description;
+              });
+            }
+          },
+          onNavigationRequest: (request) {
+            final uri = Uri.tryParse(request.url);
+            if (uri != null && !_isHttpScheme(uri)) {
+              // Launch non-http(s) URLs using the platform handler to support
+              // app redirects (e.g. SCB Easy deep links).
+              unawaited(PaymentRedirectLauncher._launchExternal(context, uri));
+              return NavigationDecision.prevent;
+            }
+            return NavigationDecision.navigate;
+          },
+        ),
+      )
+      ..loadRequest(widget.initialUrl);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final title = widget.title ?? 'ดำเนินการชำระเงิน';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        actions: [
+          IconButton(
+            onPressed: () => Navigator.of(context).maybePop(true),
+            icon: const Icon(Icons.close),
+            tooltip: 'ปิด',
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (widget.description != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                child: Text(
+                  widget.description!,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            Expanded(
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: WebViewWidget(controller: _controller),
+                  ),
+                  if (_isLoading)
+                    const Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      child: LinearProgressIndicator(minHeight: 2),
+                    ),
+                  if (_errorMessage != null)
+                    Positioned.fill(
+                      child: Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.error_outline,
+                                size: 40,
+                                color: Colors.redAccent,
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'ไม่สามารถโหลดหน้าชำระเงินได้',
+                                style: theme.textTheme.titleMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                _errorMessage!,
+                                style: theme.textTheme.bodySmall,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 16),
+                              FilledButton.icon(
+                                onPressed: () {
+                                  setState(() {
+                                    _errorMessage = null;
+                                    _isLoading = true;
+                                  });
+                                  _controller.loadRequest(widget.initialUrl);
+                                },
+                                icon: const Icon(Icons.refresh),
+                                label: const Text('ลองใหม่อีกครั้ง'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   printing: ^5.12.0
   go_router: ^14.2.0
   url_strategy: ^0.2.0
+  url_launcher: ^6.3.0
   firebase_remote_config: ^5.0.3
   firebase_storage: ^12.1.0
   cloud_functions: ^5.0.3


### PR DESCRIPTION
## Summary
- add a reusable payment redirect launcher with WebView support that also hands off deep links to installed banking apps
- trigger the redirect helper from the checkout flow when Omise 3-D Secure or mobile banking payments need additional authorization
- include url_launcher dependency to enable external deep-link launches

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e61e4838c08325aecc83c32bc3fde9