### PR TITLE
Fix analyzer warnings across checkout and utilities

### DIFF
--- a/lib/admin/modifier_management_page.dart
+++ b/lib/admin/modifier_management_page.dart
@@ -72,15 +72,19 @@ class _ModifierManagementPageState extends State<ModifierManagementPage> {
 
   // --- FIX: Added 'async' to the function signature ---
   Future<void> _showModifierGroupDialog({ModifierGroup? existingGroup}) async {
-    final bool isNew = existingGroup == null;
-    final group = isNew
-        ? ModifierGroup()
-        : ModifierGroup.fromFirestore(
-            await _firestore
-                .collection('modifierGroups')
-                .doc(existingGroup!.id)
-                .get(),
-          );
+    final ModifierGroup? initialGroup = existingGroup;
+    final bool isNew = initialGroup == null;
+
+    late ModifierGroup group;
+    if (initialGroup == null) {
+      group = ModifierGroup();
+    } else {
+      final snapshot = await _firestore
+          .collection('modifierGroups')
+          .doc(initialGroup.id)
+          .get();
+      group = ModifierGroup.fromFirestore(snapshot);
+    }
 
     if (!mounted) return;
 

--- a/lib/checkout_page.dart
+++ b/lib/checkout_page.dart
@@ -1349,9 +1349,9 @@ class _CheckoutPageState extends State<CheckoutPage> {
     };
 
     try {
-      await orderRef.update(payload);
+      await _orderRef.update(payload);
       await _handlePostPaymentSuccess(
-        orderRef,
+        _orderRef,
         successMessage: 'Payment confirmed successfully!',
       );
     } catch (e) {
@@ -1805,6 +1805,10 @@ class _CheckoutPageState extends State<CheckoutPage> {
         });
       }
     }
+  }
+
+  Future<void> _handlePrintReceipt() {
+    return _printViaEscPos();
   }
 
   Future<void> _handlePostPaymentSuccess(

--- a/lib/utils/promptpay_qr_generator.dart
+++ b/lib/utils/promptpay_qr_generator.dart
@@ -46,7 +46,7 @@ class PromptPayQrGenerator {
 
     final withoutChecksum = payload.toString();
     final checksum = _calculateCrc16('${withoutChecksum}6304');
-    return '$withoutChecksum6304$checksum';
+    return '${withoutChecksum}6304$checksum';
   }
 
   static const String _promptPayAid = 'A000000677010111';

--- a/lib/widgets/omise_card_tokenizer.dart
+++ b/lib/widgets/omise_card_tokenizer.dart
@@ -200,7 +200,7 @@ class _OmiseCardTokenizationPageState
       ..writeln('      }')
       ..writeln('    }')
       ..writeln('    function formatCardNumber(value) {')
-      ..writeln('      return value.replace(/[^0-9]/g, "").replace(/(.{4})/g, "$1 ").trim();')
+      ..writeln('      return value.replace(/[^0-9]/g, "").replace(/(.{4})/g, "\$1 ").trim();')
       ..writeln('    }')
       ..writeln('    document.addEventListener("DOMContentLoaded", () => {')
       ..writeln('      if (!PUBLIC_KEY) {')
@@ -253,7 +253,7 @@ class _OmiseCardTokenizationPageState
       ..writeln('      });')
       ..writeln('      const amountLabel = document.getElementById("amount-label");')
       ..writeln('      if (DISPLAY_AMOUNT && amountLabel) {')
-      ..writeln('        amountLabel.textContent = `ยอดเรียกเก็บ ${DISPLAY_CURRENCY} ${DISPLAY_AMOUNT}`;')
+      ..writeln('        amountLabel.textContent = `ยอดเรียกเก็บ \${DISPLAY_CURRENCY} \${DISPLAY_AMOUNT}`;')
       ..writeln('        amountLabel.style.display = "block";')
       ..writeln('      }');
     buffer

--- a/lib/widgets/payment_redirect_page.dart
+++ b/lib/widgets/payment_redirect_page.dart
@@ -126,7 +126,7 @@ class _PaymentRedirectPageState extends State<_PaymentRedirectPage> {
           },
           onNavigationRequest: (request) {
             final uri = Uri.tryParse(request.url);
-            if (uri != null && !_isHttpScheme(uri)) {
+            if (uri != null && !PaymentRedirectLauncher._isHttpScheme(uri)) {
               // Launch non-http(s) URLs using the platform handler to support
               // app redirects (e.g. SCB Easy deep links).
               unawaited(PaymentRedirectLauncher._launchExternal(context, uri));


### PR DESCRIPTION
## Summary
- prevent unnecessary null assertion when loading modifier groups
- reference the initialized order document and add a print handler hook
- repair string escaping and checksum assembly in PromptPay and Omise utilities, and reuse the HTTP scheme helper

## Testing
- not run (flutter tooling unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e62782562483259bd1700942b820c8