### PR TITLE
Guard desktop background dispatcher from Firestore

### DIFF
--- a/lib/background/background_sync.dart
+++ b/lib/background/background_sync.dart
@@ -43,6 +43,9 @@ void backgroundSyncDispatcher() {
     }
     try {
       WidgetsFlutterBinding.ensureInitialized();
+      if (!_supportsBackgroundSync) {
+        return true;
+      }
       await BackgroundSyncManager.instance.ensureInitialized();
       ensureBackgroundPlugins();
 


### PR DESCRIPTION
## Summary
- prevent the background sync dispatcher from initializing Firebase on unsupported desktop platforms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63813160c832581fcb802cde52256