### PR TITLE
Check Omise secret key before launching card flow

### DIFF
--- a/lib/checkout_page.dart
+++ b/lib/checkout_page.dart
@@ -1230,6 +1230,8 @@ class _CheckoutPageState extends State<CheckoutPage> {
       final config = gatewayService.activeConfig;
       final publicKey =
           config?.apiKey ?? config?.additionalData['publicKey'] as String?;
+      final secretKey =
+          config?.secretKey ?? config?.additionalData['secretKey'] as String?;
 
       if (publicKey == null || publicKey.isEmpty) {
         if (mounted) {
@@ -1239,6 +1241,21 @@ class _CheckoutPageState extends State<CheckoutPage> {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               content: Text('Unable to process card payment: Omise public key is missing.'),
+            ),
+          );
+        }
+        return;
+      }
+
+      if (secretKey == null || secretKey.isEmpty) {
+        if (mounted) {
+          setState(() {
+            _isConfirming = false;
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content:
+                  Text('Unable to process card payment: Omise secret key is missing.'),
             ),
           );
         }


### PR DESCRIPTION
## Summary
- ensure the Omise card payment flow verifies both the public and secret keys before tokenizing
- prevent users from entering card details when the secret key is missing by showing an error message early

## Testing
- flutter analyze *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65e2bc0d883259b8a1dba02e08322